### PR TITLE
support for using the widget manually

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -17,6 +17,25 @@
   {{/if}}-->
 
   <form id="configuration">
+    <div class="panel panel-info">
+      <div class="panel-heading">Add-on settings</div>
+      <div class="panel-body">
+        <div class="form-group">
+          <p>
+            <input type="checkbox" name="showAutomatically" value="1" {{#if showAutomatically}}checked{{/if}} />
+            Show the popup automatically
+          </p>
+          <p>If the above is not checked, you can trigger the push notifications yourself using the following code:</p>
+          <pre><code>var pushWidget = Fliplet.Widget.get('PushNotifications');
+
+pushWidget.ask().then(function (subscriptionId) {
+  // user pressed allow and has been registered
+}, function (err) {
+  // contains code and message
+})</code></pre>
+        </div>
+      </div>
+    </div>
     <div class="panel panel-default {{#if gcm}}panel-success{{/if}}">
       <div class="panel-heading">Android configuration {{#if gcm}}<i class="glyphicon glyphicon-ok"></i>{{/if}}</div>
       <div class="panel-body">

--- a/js/interface.js
+++ b/js/interface.js
@@ -10,7 +10,8 @@ $('#configuration').submit(function (event) {
     apnTeamId: $('[name="apnTeamId"]').val(),
     apnTopic: $('[name="apnTopic"]').val(),
     wnsClientId: $('[name="wnsClientId"]').val(),
-    wnsClientSecret: $('[name="wnsClientSecret"]').val()
+    wnsClientSecret: $('[name="wnsClientSecret"]').val(),
+    showAutomatically: $('[name="showAutomatically"]').is(':checked')
   };
 
   data.gcm = !!(data.gcmSenderId && data.gcmServerKey && data.gcmPackageName);

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -18,7 +18,6 @@ Fliplet.Widget.register('PushNotifications', function () {
   }
 
   function markAsSeen() {
-    console.log('marking as seen')
     return Fliplet.Storage.set(key, Date.now());
   }
 

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,4 +1,4 @@
-(function () {
+Fliplet.Widget.register('PushNotifications', function () {
 
   var id = $('[data-push-notification-id]').data('push-notification-id');
   var data = Fliplet.Widget.getData(id);
@@ -18,37 +18,69 @@
   }
 
   function markAsSeen() {
+    console.log('marking as seen')
     return Fliplet.Storage.set(key, Date.now());
   }
 
-  Fliplet.Navigator.onReady().then(function () {
-    return Fliplet.Storage.get(key);
-  }).then(function (value) {
-    if (value) {
-      return removeFromDom();
-    }
+  function ask() {
+    return new Promise(function (resolve, reject) {
+      $popup.find('[data-allow]').one('click', function () {
+        dismiss();
 
-    $popup.find('[data-allow]').click(function () {
-      dismiss();
-      Fliplet.User.subscribe(data).then(function () {
-        markAsSeen();
-      }, function (err) {
-        alert(err);
-        markAsSeen();
+        Fliplet.Navigator.onReady().then(function (){
+          return Fliplet.User.subscribe(data);
+        }).then(function (subscriptionId) {
+          markAsSeen();
+          resolve(subscriptionId);
+        }, function (err) {
+          alert(err);
+          markAsSeen();
+
+          reject({
+            code: 1,
+            message: err
+          });
+        });
       });
+
+      $popup.find('[data-dont-allow]').one('click', function () {
+        dismiss();
+        markAsSeen();
+
+        reject({
+          code: 2,
+          message: 'The user did not allow push notifications.'
+        });
+      });
+
+      $popup.find('[data-remind]').one('click', function () {
+        dismiss();
+        markAsSeen();
+
+        reject({
+          code: 3,
+          message: 'The user pressed the "remind later" button.'
+        });
+      });
+
+      $popup.addClass('ready');
     });
+  }
 
-    $popup.find('[data-dont-allow]').click(function () {
-      dismiss();
-      markAsSeen();
+  if (data.showAutomatically) {
+    Fliplet.Storage.get(key).then(function (alreadyShown) {
+      console.log(alreadyShown)
+      if (!alreadyShown) {
+        ask();
+      }
     });
+  }
 
-    $popup.find('[data-remind]').click(function () {
-      dismiss();
-      markAsSeen();
-    });
+  return {
+    ask: ask,
+    reset: function () {
+      return Fliplet.Storage.remove(key);
+    }
+  };
 
-    $popup.addClass('ready');
-  });
-
-})();
+});


### PR DESCRIPTION
Requires https://github.com/Fliplet/fliplet-api/pull/763

```js
// This triggers an error if the plugin hasn't been registered, so you can easily see whether the plugin need to be enabled before using this code
var pushWidget = Fliplet.Widget.get('PushNotifications');

// Subscribe the user
pushWidget.ask().then(function (subscriptionId) {
  // the user subscribed
}, function (err) {
  // err contains code and message
});

// Reset the status of the plugin. This means if the user pressed "don't allow" you can force the plugin to be displayed again with ask()
pushWidget.reset();
```