### PR TITLE
Push Notifications improvements and refactor

### DIFF
--- a/build.html
+++ b/build.html
@@ -1,4 +1,4 @@
-<!-- push notifications -->
+<!-- Push notifications component -->
 <div class="popup-screen" data-push-notification-id="{{id}}">
   <div class="popup-wrapper">
     <div class="popup-content">
@@ -25,4 +25,4 @@
     </div>
   </div>
 </div>
-<!-- end of push notifications -->
+<!-- End of Push notifications -->

--- a/interface.html
+++ b/interface.html
@@ -190,9 +190,9 @@
 
 pushWidget.ask().then(function (subscriptionId) {
   // user pressed allow and has been registered
-}, function (err) {
+}.catch(function (err) {
   // contains code and message
-})</code></pre>
+});</code></pre>
             </div>
           </div>
           <div class="form-group clearfix">

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -97,13 +97,12 @@ Fliplet.Widget.register('PushNotifications', function () {
       return new Promise(function (resolve, reject) {
         $popup.find('[data-allow]').one('click', function () {
           dismiss();
-          markAsSeen('allow');
-
-          Fliplet.Navigator.onReady().then(function () {
-            return subscribeUser();
-          }).then(function (subscriptionId) {
+          
+          markAsSeen('allow').then(function () {
+            return Fliplet();
+          }).then(function () {
             resolve(subscriptionId);
-          }, function (err) {
+          }).catch(function (err) {
             console.error(err);
 
             reject({
@@ -115,22 +114,22 @@ Fliplet.Widget.register('PushNotifications', function () {
 
         $popup.find('[data-dont-allow]').one('click', function () {
           dismiss();
-          markAsSeen('disallow');
-
-          reject({
-            code: 2,
-            message: 'The user did not allow push notifications.'
-          });
+          markAsSeen('disallow').then(function () {
+            reject({
+              code: 2,
+              message: 'The user did not allow push notifications.'
+            }); 
+          }).catch(reject);
         });
 
         $popup.find('[data-remind]').one('click', function () {
           dismiss();
-          markAsSeen('remind');
-
-          reject({
-            code: 3,
-            message: 'The user pressed the "remind later" button.'
-          });
+          markAsSeen('remind').then(function () {
+            reject({
+              code: 3,
+              message: 'The user pressed the "remind later" button.'
+            });
+          }).catch(reject);
         });
 
         $popup.addClass('ready');
@@ -140,7 +139,7 @@ Fliplet.Widget.register('PushNotifications', function () {
     return askPromise;
   }
 
-  Fliplet.Navigator.onReady().then(function () {
+  Fliplet().then(function () {
     return Fliplet.Storage.get(key);
   }).then(function (alreadyShown) {
     Fliplet.User.getSubscriptionId().then(function (isSubscribed) {

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -82,9 +82,7 @@ Fliplet.Widget.register('PushNotifications', function () {
       return askPromise;
     }
 
-    askPromise = Fliplet.Storage.get(key);
-
-    askPromise.then(function (value) {
+    askPromise = Fliplet.Storage.get(key).then(function (value) {
       if (!value || value.indexOf('disallow') === -1) {
         return Promise.resolve();
       }

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -87,6 +87,13 @@ Fliplet.Widget.register('PushNotifications', function () {
       return new Promise(function () {});
     }
 
+    if (Fliplet.Env.is('web') && Fliplet.Env.get('mode') === 'view') {
+      return Promise.reject({
+        code: -1,
+        message: 'Push notifications are not supported on the web platform yet.'
+      });
+    }
+
     if (askPromise) {
       return askPromise;
     }

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -75,11 +75,16 @@ Fliplet.Widget.register('PushNotifications', function () {
 
   function ask() {
     if (!data || !isConfigured) {
-      return Promise.reject('Please configure your push notification settings first.');
+      return Promise.reject({
+        code: 0,
+        message: 'Please configure your push notification settings first.'
+      });
     }
 
+    // Push notifications are not enabled while using edit mode in Fliplet Studio.
+    // We just return a promise that is never fulfilled.
     if (Fliplet.Env.get('interact')) {
-      return Promise.reject('Push notifications are not enabled while using edit mode in Fliplet Studio.')
+      return new Promise(function () {});
     }
 
     if (askPromise) {

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -13,7 +13,7 @@ Fliplet.Widget.register('PushNotifications', function () {
   }
 
   if (!data || !isConfigured) {
-    return removeFromDom();
+    removeFromDom();
   }
 
   function removeFromDom() {
@@ -74,6 +74,10 @@ Fliplet.Widget.register('PushNotifications', function () {
   }
 
   function ask() {
+    if (!data || !isConfigured) {
+      return Promise.reject('Please configure your push notification settings first.');
+    }
+
     if (askPromise) {
       return askPromise;
     }
@@ -142,6 +146,10 @@ Fliplet.Widget.register('PushNotifications', function () {
   Fliplet().then(function () {
     return Fliplet.Storage.get(key);
   }).then(function (alreadyShown) {
+    if (!data || !isConfigured) {
+      return;
+    }
+
     Fliplet.User.getSubscriptionId().then(function (isSubscribed) {
       var push = Fliplet.User.getPushNotificationInstance(data);
 
@@ -189,5 +197,4 @@ Fliplet.Widget.register('PushNotifications', function () {
       return Fliplet.Storage.remove(key);
     }
   };
-
 });


### PR DESCRIPTION
Various improvements to rewrite a year old's logic such as:

- code doesn't fail when being tested in studio (because `pushWidget` is now defined as it should despite not doing anything on web)
- popup gets displayed on preview mode in studio (but not on webapps) so you can consistently check whether they are enabled correctly before publishing the app
- calling `ask()` multiple times now correctly checks whether notifications were allowed by the user (this fixes the NWP issue)