### PR TITLE
Added masterPageId to the condition when looking for pages

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -40,7 +40,7 @@ Fliplet.Widget.register('PushNotifications', function () {
     var appPages = Fliplet.Env.get('appPages');
 
     if (Array.isArray(appPages) && appPages.length) {
-      var page = appPages.filter(function(page) { return page.id === parseInt(data.page);});
+      var page = appPages.filter(function(page) { return page.masterPageId === parseInt(data.page) || page.id === parseInt(data.page);});
 
       if (!page.length || Fliplet.Env.get('pageId') === parseInt(data.page)) {
         Fliplet.Native.Updates.checkForUpdates(Fliplet.Env.get('appId'), true, null, data);


### PR DESCRIPTION
Added a `masterPageId` condition when figuring out if the page exists, just like `navigate` does.