### PR TITLE
Fixed a case where multiple deep link settings would show

### DIFF
--- a/js/interface-uipushnotification.js
+++ b/js/interface-uipushnotification.js
@@ -188,6 +188,7 @@ var UIPushNotification = (function() {
   }
 
   UIPushNotification.prototype.linkProviderInit = function() {
+    $('#push-link-provider').empty();
     _this.linkActionProvider = Fliplet.Widget.open('com.fliplet.link', {
       // If provided, the iframe will be appended here,
       // otherwise will be displayed as a full-size iframe overlay


### PR DESCRIPTION
This fixes a bug I noticed, where the deep link settings will get duplicated as many times as you switch the tab to push notifications and open them. 