### PR TITLE
Bug/ios background transition

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -51,31 +51,31 @@ Fliplet.Widget.register('PushNotifications', function () {
         clearNotifications();
       }, 1);
 
-			if (subscriptionId) {
-				push.on('notification', function (data) {
-					Fliplet.Hooks.run('pushNotification', data).then(function () {
-						if (data.additionalData) {
-							if (data.additionalData.foreground) {
-								handleForegroundNotification(data);
-								return;
-							}
+      if (subscriptionId) {
+        push.on('notification', function (data) {
+          Fliplet.Hooks.run('pushNotification', data).then(function () {
+            if (data.additionalData) {
+              if (data.additionalData.foreground) {
+                handleForegroundNotification(data);
+                return;
+              }
               /**
                * background notifications seem to open the application quite fast
                * and sometimes the transition is not applied
                * the 300ms delay we have introduced here should allow for it to animate
                */
-							handleNotificationPayload(
-								data.additionalData.customData,
-								Modernizr.ios && !data.additionalData.coldstart && !data.additionalData.foreground
-									? IOS_BACKGROUND_TRANSITION_DELAY
-									: null
-							);
-						}
-					});
-				});
+              handleNotificationPayload(
+                data.additionalData.customData,
+                Modernizr.ios && !data.additionalData.coldstart && !data.additionalData.foreground
+                  ? IOS_BACKGROUND_TRANSITION_DELAY
+                  : null
+              );
+            }
+          });
+        });
 
-				bindLocalNotificationsClick();
-			}
+        bindLocalNotificationsClick();
+      }
     }
     return push;
   }


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-api/pull/2447#issuecomment-459459147
Background notifications seem to open the application quite fast and sometimes the transition is not applied the 300ms delay we have introduced here should allow for it to animate