### PR TITLE
Fixes notification permission popup styling

### DIFF
--- a/css/notifications.css
+++ b/css/notifications.css
@@ -6,7 +6,7 @@
     left: 0;
     right: 0;
     background-color: rgba(0, 0, 0, 0.45);
-    z-index: 20;
+    z-index: 1011;
     opacity: 0;
     visibility: hidden;
     -webkit-transition: all 0.3s ease;

--- a/css/notifications.css
+++ b/css/notifications.css
@@ -20,9 +20,7 @@
 
 .popup-wrapper {
     position: absolute;
-    top: 5%;
-    top: calc(constant(safe-area-inset-top) + 5%);
-    top: calc(env(safe-area-inset-top) + 5%);
+    top: 50%;
     left: 5%;
     right: 5%;
     max-width: 300px;
@@ -30,6 +28,8 @@
     background-color: #FFFFFF;
     opacity: 0;
     visibility: hidden;
+    -webkit-transform: translate3d(0, -50%, 0);
+    transform: translate3d(0, -50%, 0);
     -webkit-transition: all 0.3s ease 0.2s;
     transition: all 0.3s ease 0.2s;
     z-index: 1;


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/2829

- Moves it to be above the **About this app** overlay
- Centers the popup UI

![IMG_E379683B7560-1](https://user-images.githubusercontent.com/290733/56214057-14dc9d80-6055-11e9-8b7e-da995396d722.jpeg)
