### PR TITLE
Add badge count for push notifications triggered by notifications

### DIFF
--- a/js/interface-uinotification.js
+++ b/js/interface-uinotification.js
@@ -469,7 +469,8 @@ var UINotification = (function() {
     var data = {
       title: title,
       message: message,
-      icon: 'icon_notification'
+      icon: 'icon_notification',
+      badge: 1
     };
 
     // Check if page is set for deep linking


### PR DESCRIPTION
Badge count will be set to 1 when sending a push notification via notifications. Note that normal push notifications do this already.