### PR TITLE
Corrects how timezone offsets are applied

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -2453,7 +2453,7 @@ function formatDate(value, timezone) {
   }
 
   if (!date.isValid()) {
-    console.warn('Invalid date: ' + value + '. Using current time as fallback.');
+    // Invalid date. Using current time as fallback.
     date = moment.utc();
   }
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -3781,6 +3781,9 @@ var render = function() {
                               },
                               "update:timezone": function($event) {
                                 _vm.scheduledAtTimezone = $event
+                              },
+                              "update:date": function($event) {
+                                _vm.scheduledAtDate = $event
                               }
                             }
                           })
@@ -6127,7 +6130,7 @@ __webpack_require__.r(__webpack_exports__);
       return hour12h % 24;
     },
     validateDST: function validateDST() {
-      var timestamp = moment.tz([this.date.getFullYear(), this.date.getMonth(), this.date.getDate(), this.getHour24h(this.hour, this.ampm), this.minute], this.timezone);
+      var timestamp = moment.tz([this.date.getFullYear(), this.date.getMonth(), this.date.getDate(), this.getHour24h(this.hour12h, this.ampm), this.minute], this.timezone);
 
       if (timestamp.get('hour') === this.hour) {
         return false;

--- a/dist/app.js
+++ b/dist/app.js
@@ -1001,6 +1001,7 @@ __webpack_require__.r(__webpack_exports__);
       pageCount: 0,
       lastNotificationShown: false,
       showTimezone: Object(_store__WEBPACK_IMPORTED_MODULE_5__["getShowTimezone"])(),
+      userTimezone: Object(_libs_timezones__WEBPACK_IMPORTED_MODULE_8__["validate"])(moment.tz.guess()),
       batchSize: 10,
       batchSizes: [10, 25, 50, 100, 250, 500]
     };
@@ -1070,16 +1071,15 @@ __webpack_require__.r(__webpack_exports__);
     getNotificationTimezone: function getNotificationTimezone(notification) {
       var timezone = _.get(notification, 'data._metadata.scheduledAtTimezone');
 
-      var date = moment(_.get(notification, 'orderAt')).toDate();
+      var date = moment.utc(_.get(notification, 'orderAt')).toDate();
       return Object(_libs_timezones__WEBPACK_IMPORTED_MODULE_8__["getOffsetString"])(timezone, date);
     },
     getNotificationDate: function getNotificationDate(notification) {
       if (!this.showTimezone) {
-        return "".concat(Object(_libs_date__WEBPACK_IMPORTED_MODULE_7__["formatDate"])(notification.orderAt));
+        return "".concat(Object(_libs_date__WEBPACK_IMPORTED_MODULE_7__["formatDate"])(notification.orderAt, this.userTimezone));
       }
 
-      var timezone = _.get(notification, 'data._metadata.scheduledAtTimezone');
-
+      var timezone = Object(_libs_timezones__WEBPACK_IMPORTED_MODULE_8__["validate"])(_.get(notification, 'data._metadata.scheduledAtTimezone'));
       return "".concat(Object(_libs_date__WEBPACK_IMPORTED_MODULE_7__["formatDate"])(notification.orderAt, timezone), " ").concat(this.getNotificationTimezone(notification));
     },
     getNotificationLog: function getNotificationLog(notification) {
@@ -2439,10 +2439,22 @@ function calendarDate(value) {
   });
 }
 function formatDate(value, timezone) {
-  var date = moment(value);
+  // @param value (Moment | Date | Number | String) Number would be a UNIX timestamp in seconds
+  var date;
+
+  if (value instanceof moment) {
+    date = value;
+  } else if (value instanceof Date) {
+    date = moment(value);
+  } else if (typeof value === 'number' || parseFloat(value).toString() === value) {
+    date = moment.utc(moment.unix(value));
+  } else {
+    date = moment(value);
+  }
 
   if (!date.isValid()) {
-    date = moment();
+    console.warn('Invalid date: ' + value + '. Using current time as fallback.');
+    date = moment.utc();
   }
 
   if (timezone) {
@@ -2467,6 +2479,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getOffset", function() { return getOffset; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getOffsetString", function() { return getOffsetString; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getOffsetObject", function() { return getOffsetObject; });
+var DEFAULT_TIMEZONE = 'Europe/London';
 var timezones = [{
   value: 'Etc/GMT+12',
   label: 'International Date Line West'
@@ -2716,7 +2729,7 @@ var timezones = [{
 }];
 function validate(name) {
   if (!name) {
-    throw new Error('Timezone not defined');
+    name = DEFAULT_TIMEZONE;
   }
 
   var zone = _.find(timezones, {
@@ -4687,26 +4700,28 @@ var defaultConfirmationMessage = 'Your notification is saved.';
         $and: this.filterScopes
       } : {};
     },
-    scheduledAtTimezoneOffset: function scheduledAtTimezoneOffset() {
-      return Object(_libs_timezones__WEBPACK_IMPORTED_MODULE_4__["getOffset"])(this.scheduledAtTimezone, this.scheduledAtDate);
-    },
     scheduledAt: function scheduledAt() {
-      var timestamp = new Date(this.scheduledAtDate.getFullYear(), this.scheduledAtDate.getMonth(), this.scheduledAtDate.getDate(), this.scheduledAtHour, this.scheduledAtMinute);
-      return Math.floor((timestamp.getTime() + this.scheduledAtTimezoneOffset * 6e4) / 1000);
+      var timestamp = moment([this.scheduledAtDate.getFullYear(), this.scheduledAtDate.getMonth(), this.scheduledAtDate.getDate(), this.scheduledAtHour, this.scheduledAtMinute]).tz(this.scheduledAtTimezone);
+      return timestamp.utc().unix();
     },
     orderAt: function orderAt() {
+      var orderAt;
+
       if (this.schedule === 'now') {
-        return moment().unix();
+        orderAt = moment().unix();
+      } else {
+        orderAt = this.scheduledAt;
       }
 
-      return this.scheduledAt;
+      return orderAt;
     },
     notificationTimezone: function notificationTimezone() {
       var date = moment.unix(this.orderAt).toDate();
       return Object(_libs_timezones__WEBPACK_IMPORTED_MODULE_4__["getOffsetString"])(this.scheduledAtTimezone, date);
     },
     notificationDate: function notificationDate() {
-      return "".concat(Object(_libs_date__WEBPACK_IMPORTED_MODULE_3__["formatDate"])(moment.unix(this.orderAt - this.scheduledAtTimezoneOffset * 60), this.scheduledAtTimezone), " ").concat(this.notificationTimezone);
+      var notificationDate = "".concat(Object(_libs_date__WEBPACK_IMPORTED_MODULE_3__["formatDate"])(this.orderAt, this.scheduledAtTimezone), " ").concat(this.notificationTimezone);
+      return notificationDate;
     },
     type: function type() {
       if (this.notificationHasChannel('in-app') || !this.notificationHasChannel('push')) {

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -149,7 +149,7 @@
                 :hour.sync="scheduledAtHour"
                 :minute.sync="scheduledAtMinute"
                 :timezone.sync="scheduledAtTimezone"
-                :date="scheduledAtDate"
+                :date.sync="scheduledAtDate"
               ></Timepicker>
             </div>
           </div>

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -240,7 +240,6 @@ import { filterTypes, getFilterScope, getFilterVerbose } from '../libs/scope';
 import { formatDate } from '../libs/date';
 import {
   validate as validateTimezone,
-  getOffset as getTimezoneOffset,
   getOffsetString as getTimezoneOffsetString
 } from '../libs/timezones';
 import Tooltip from './Tooltip';
@@ -430,26 +429,27 @@ export default {
 
       return this.filterScopes.length ? { $and: this.filterScopes } : {};
     },
-    scheduledAtTimezoneOffset() {
-      return getTimezoneOffset(this.scheduledAtTimezone, this.scheduledAtDate);
-    },
     scheduledAt() {
-      const timestamp = new Date(
+      const timestamp = moment([
         this.scheduledAtDate.getFullYear(),
         this.scheduledAtDate.getMonth(),
         this.scheduledAtDate.getDate(),
         this.scheduledAtHour,
         this.scheduledAtMinute
-      );
+      ]).tz(this.scheduledAtTimezone);
 
-      return Math.floor((timestamp.getTime() + this.scheduledAtTimezoneOffset * 6e4) / 1000);
+      return timestamp.utc().unix();
     },
     orderAt() {
+      let orderAt;
+
       if (this.schedule === 'now') {
-        return moment().unix();
+        orderAt = moment().unix();
+      } else {
+        orderAt = this.scheduledAt;
       }
 
-      return this.scheduledAt;
+      return orderAt;
     },
     notificationTimezone() {
       const date = moment.unix(this.orderAt).toDate();
@@ -457,7 +457,9 @@ export default {
       return getTimezoneOffsetString(this.scheduledAtTimezone, date);
     },
     notificationDate() {
-      return `${formatDate(moment.unix(this.orderAt - this.scheduledAtTimezoneOffset * 60), this.scheduledAtTimezone)} ${this.notificationTimezone}`;
+      const notificationDate = `${formatDate(this.orderAt, this.scheduledAtTimezone)} ${this.notificationTimezone}`;
+
+      return notificationDate;
     },
     type() {
       if (this.notificationHasChannel('in-app') || !this.notificationHasChannel('push')) {

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -441,15 +441,11 @@ export default {
       return timestamp.utc().unix();
     },
     orderAt() {
-      let orderAt;
-
-      if (this.schedule === 'now') {
-        orderAt = moment().unix();
-      } else {
-        orderAt = this.scheduledAt;
+      if (this.schedule === 'scheduled') {
+        return this.scheduledAt;
       }
 
-      return orderAt;
+      return moment().unix();
     },
     notificationTimezone() {
       const date = moment.unix(this.orderAt).toDate();
@@ -457,9 +453,7 @@ export default {
       return getTimezoneOffsetString(this.scheduledAtTimezone, date);
     },
     notificationDate() {
-      const notificationDate = `${formatDate(this.orderAt, this.scheduledAtTimezone)} ${this.notificationTimezone}`;
-
-      return notificationDate;
+      return `${formatDate(this.orderAt, this.scheduledAtTimezone)} ${this.notificationTimezone}`;
     },
     type() {
       if (this.notificationHasChannel('in-app') || !this.notificationHasChannel('push')) {

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -430,13 +430,13 @@ export default {
       return this.filterScopes.length ? { $and: this.filterScopes } : {};
     },
     scheduledAt() {
-      const timestamp = moment([
+      const timestamp = moment.tz([
         this.scheduledAtDate.getFullYear(),
         this.scheduledAtDate.getMonth(),
         this.scheduledAtDate.getDate(),
         this.scheduledAtHour,
         this.scheduledAtMinute
-      ]).tz(this.scheduledAtTimezone);
+      ], this.scheduledAtTimezone);
 
       return timestamp.utc().unix();
     },

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -112,7 +112,8 @@ import {
 import bus from '../libs/bus';
 import { formatDate } from '../libs/date';
 import {
-  getOffsetString as getTimezoneOffsetString
+  getOffsetString as getTimezoneOffsetString,
+  validate as validateTimezone
 } from '../libs/timezones';
 
 export default {
@@ -124,6 +125,7 @@ export default {
       pageCount: 0,
       lastNotificationShown: false,
       showTimezone: getShowTimezone(),
+      userTimezone: validateTimezone(moment.tz.guess()),
       batchSize: 10,
       batchSizes: [10, 25, 50, 100, 250, 500]
     };
@@ -192,16 +194,16 @@ export default {
     },
     getNotificationTimezone(notification) {
       const timezone = _.get(notification, 'data._metadata.scheduledAtTimezone');
-      const date = moment(_.get(notification, 'orderAt')).toDate();
+      const date = moment.utc(_.get(notification, 'orderAt')).toDate();
 
       return getTimezoneOffsetString(timezone, date);
     },
     getNotificationDate(notification) {
       if (!this.showTimezone) {
-        return `${formatDate(notification.orderAt)}`;
+        return `${formatDate(notification.orderAt, this.userTimezone)}`;
       }
 
-      const timezone = _.get(notification, 'data._metadata.scheduledAtTimezone');
+      const timezone = validateTimezone(_.get(notification, 'data._metadata.scheduledAtTimezone'));
 
       return `${formatDate(notification.orderAt, timezone)} ${this.getNotificationTimezone(notification)}`;
     },

--- a/src/components/Timepicker.vue
+++ b/src/components/Timepicker.vue
@@ -149,7 +149,7 @@ export default {
         this.date.getFullYear(),
         this.date.getMonth(),
         this.date.getDate(),
-        this.getHour24h(this.hour, this.ampm),
+        this.getHour24h(this.hour12h, this.ampm),
         this.minute
       ], this.timezone);
 

--- a/src/components/Timepicker.vue
+++ b/src/components/Timepicker.vue
@@ -88,17 +88,33 @@ export default {
     }
   },
   watch: {
+    date() {
+      this.validateDST();
+    },
     hour12h(value) {
+      const hourChanged = this.validateDST();
+
+      if (hourChanged) {
+        return;
+      }
+
       this.$emit('update:hour', this.getHour24h(value, this.ampm));
     },
     minute(value) {
       this.$emit('update:minute', value);
     },
     ampm(value) {
+      const hourChanged = this.validateDST();
+
+      if (hourChanged) {
+        return;
+      }
+
       this.$emit('update:hour', this.getHour24h(this.hour12h, value));
     },
     timezone(value) {
-      this.$emit('update:timezone', validateTimezone(value));
+      this.validateDST();
+      this.$emit('update:timezone', value);
     }
   },
   computed: {
@@ -113,6 +129,9 @@ export default {
       }), ['offset'], ['desc']);
     }
   },
+  mounted() {
+    this.validateDST();
+  },
   methods: {
     getHour24h(hour12h, ampm) {
       if (hour12h === 12) {
@@ -124,6 +143,22 @@ export default {
       }
 
       return hour12h % 24;
+    },
+    validateDST() {
+      const timestamp = moment.tz([
+        this.date.getFullYear(),
+        this.date.getMonth(),
+        this.date.getDate(),
+        this.getHour24h(this.hour, this.ampm),
+        this.minute
+      ], this.timezone);
+
+      if (timestamp.get('hour') === this.hour) {
+        return false;
+      }
+
+      this.hour12h = timestamp.get('hour') % 12 || 12;
+      return true;
     }
   }
 };

--- a/src/libs/date.js
+++ b/src/libs/date.js
@@ -85,7 +85,7 @@ export function formatDate(value, timezone) {
   }
 
   if (!date.isValid()) {
-    console.warn('Invalid date: ' + value + '. Using current time as fallback.');
+    // Invalid date. Using current time as fallback.
     date = moment.utc();
   }
 

--- a/src/libs/date.js
+++ b/src/libs/date.js
@@ -71,10 +71,22 @@ export function calendarDate(value) {
 }
 
 export function formatDate(value, timezone) {
-  let date = moment(value);
+  // @param value (Moment | Date | Number | String) Number would be a UNIX timestamp in seconds
+  let date;
+
+  if (value instanceof moment) {
+    date = value;
+  } else if (value instanceof Date) {
+    date = moment(value);
+  } else if (typeof value === 'number' || parseFloat(value).toString() === value) {
+    date = moment.utc(moment.unix(value));
+  } else {
+    date = moment(value);
+  }
 
   if (!date.isValid()) {
-    date = moment();
+    console.warn('Invalid date: ' + value + '. Using current time as fallback.');
+    date = moment.utc();
   }
 
   if (timezone) {

--- a/src/libs/timezones.js
+++ b/src/libs/timezones.js
@@ -1,3 +1,5 @@
+var DEFAULT_TIMEZONE = 'Europe/London';
+
 export const timezones = [
   {
     value: 'Etc/GMT+12',
@@ -331,7 +333,7 @@ export const timezones = [
 
 export function validate(name) {
   if (!name) {
-    throw new Error('Timezone not defined');
+    name = DEFAULT_TIMEZONE;
   }
 
   let zone = _.find(timezones, { value: name });


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/5971

This PR goes through all the date parsing mechanisms to ensure they assume UTC time is the format that all timestamps are provided.