### PR TITLE
Added messages for push failures

### DIFF
--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -249,7 +249,7 @@ export default {
         InvalidProviderToken: 'The APN Key ID, push certificate or Team ID is not valid. Please double-check your settings.',
         MismatchSenderId: 'The Android push notification settings for GCM incorrectly use the Project ID instead of the Sender ID',
         DeviceTokenNotForTopic: 'The target bundle identifier does not match the one being used by some of the subscribed devices.',
-        TopicDisallowed: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
+        TopicDisallowed: 'The target bundle identifier does not match the one being used by some of the subscribed devices.',
         GCMNotSet: 'Push notifications for Firebase (Android devices) have not been configured.',
         APNNotSet: 'Push notifications for Apple (iOS devices) have not been configured.'
       };

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -246,7 +246,7 @@ export default {
       const errorTypes = {
         NoSubscriptions: 'One or more devices are not subscribed to receive this push notification.',
         NotRegistered: 'Device is not subscribed to receive this push notification or the app could be uninstalled.',
-        InvalidProviderToken: 'The APN Key ID, push certificate or Team ID are not valid. Please double check the settings you have set.',
+        InvalidProviderToken: 'The APN Key ID, push certificate or Team ID is not valid. Please double-check your settings.',
         MismatchSenderId: 'The Android push notification settings for GCM incorrectly use the Project ID instead of the Sender ID',
         DeviceTokenNotForTopic: 'The target bundle identifier does not match the one being used by some of the subscribed devices.',
         TopicDisallowed: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -244,7 +244,14 @@ export default {
       };
 
       const errorTypes = {
-        NotRegistered: 'Device is not subscribed to receive this push notification or the app could be uninstalled.'
+        NoSubscriptions: 'One or more devices are not subscribed to receive this push notification.',
+        NotRegistered: 'Device is not subscribed to receive this push notification or the app could be uninstalled.',
+        InvalidProviderToken: 'The APN Key ID, push certificate or Team ID are not valid. Please double check the settings you have set.',
+        MismatchSenderId: 'The Android push notification settings for GCM incorrectly use the Project ID instead of the Sender ID',
+        DeviceTokenNotForTopic: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
+        TopicDisallowed: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
+        GCMNotSet: 'Push notifications for Firebase (Android devices) have not been set.',
+        APNNotSet: 'Push Notifications for Apple (iOS devices) have not been set.'
       };
 
       data.errors = _.orderBy(_.map(_.keys(allErrors), (type) => {

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -248,7 +248,7 @@ export default {
         NotRegistered: 'Device is not subscribed to receive this push notification or the app could be uninstalled.',
         InvalidProviderToken: 'The APN Key ID, push certificate or Team ID are not valid. Please double check the settings you have set.',
         MismatchSenderId: 'The Android push notification settings for GCM incorrectly use the Project ID instead of the Sender ID',
-        DeviceTokenNotForTopic: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
+        DeviceTokenNotForTopic: 'The target bundle identifier does not match the one being used by some of the subscribed devices.',
         TopicDisallowed: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
         GCMNotSet: 'Push notifications for Firebase (Android devices) have not been configured.',
         APNNotSet: 'Push notifications for Apple (iOS devices) have not been configured.'

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -250,7 +250,7 @@ export default {
         MismatchSenderId: 'The Android push notification settings for GCM incorrectly use the Project ID instead of the Sender ID',
         DeviceTokenNotForTopic: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
         TopicDisallowed: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
-        GCMNotSet: 'Push notifications for Firebase (Android devices) have not been set.',
+        GCMNotSet: 'Push notifications for Firebase (Android devices) have not been configured.',
         APNNotSet: 'Push notifications for Apple (iOS devices) have not been configured.'
       };
 

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -251,7 +251,7 @@ export default {
         DeviceTokenNotForTopic: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
         TopicDisallowed: 'The target bundle identifier does not match with the one being used by some of the subscribed devices.',
         GCMNotSet: 'Push notifications for Firebase (Android devices) have not been set.',
-        APNNotSet: 'Push Notifications for Apple (iOS devices) have not been set.'
+        APNNotSet: 'Push notifications for Apple (iOS devices) have not been configured.'
       };
 
       data.errors = _.orderBy(_.map(_.keys(allErrors), (type) => {

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -245,7 +245,7 @@ export default {
 
       const errorTypes = {
         NoSubscriptions: 'One or more devices are not subscribed to receive this push notification.',
-        NotRegistered: 'Device is not subscribed to receive this push notification or the app could be uninstalled.',
+        NotRegistered: 'One or more devices are not subscribed to receive this push notification or the app could be uninstalled.',
         InvalidProviderToken: 'The APN Key ID, push certificate or Team ID is not valid. Please double-check your settings.',
         MismatchSenderId: 'The Android push notification settings for GCM incorrectly use the Project ID instead of the Sender ID',
         DeviceTokenNotForTopic: 'The target bundle identifier does not match the one being used by some of the subscribed devices.',


### PR DESCRIPTION
We do not need messages to be dynamic because they wouldn't necessarily help the user with fixing the problem.