### PR TITLE
Improves tooltip messages

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -427,55 +427,68 @@ var render = function() {
                                       _c(
                                         "p",
                                         [
-                                          notification.status === "draft"
-                                            ? _c(
-                                                "span",
-                                                {
-                                                  staticClass:
-                                                    "label label-default"
-                                                },
-                                                [_vm._v("Draft")]
-                                              )
-                                            : [
-                                                notification.status ===
-                                                "scheduled"
-                                                  ? _c(
-                                                      "span",
-                                                      {
-                                                        staticClass:
-                                                          "label label-info"
-                                                      },
-                                                      [
-                                                        _vm._v(
-                                                          "Scheduled for " +
-                                                            _vm._s(
-                                                              _vm.getNotificationDate(
-                                                                notification
-                                                              )
+                                          _c(
+                                            "tooltip",
+                                            {
+                                              attrs: {
+                                                title: _vm.getNotificationTooltip(
+                                                  notification
+                                                )
+                                              }
+                                            },
+                                            [
+                                              notification.status === "draft"
+                                                ? _c(
+                                                    "span",
+                                                    {
+                                                      staticClass:
+                                                        "label label-default"
+                                                    },
+                                                    [_vm._v("Draft")]
+                                                  )
+                                                : [
+                                                    notification.status ===
+                                                    "scheduled"
+                                                      ? _c(
+                                                          "span",
+                                                          {
+                                                            staticClass:
+                                                              "label label-info"
+                                                          },
+                                                          [
+                                                            _vm._v(
+                                                              "Scheduled for " +
+                                                                _vm._s(
+                                                                  _vm.getNotificationDate(
+                                                                    notification
+                                                                  )
+                                                                )
                                                             )
+                                                          ]
                                                         )
-                                                      ]
-                                                    )
-                                                  : _c(
-                                                      "span",
-                                                      {
-                                                        staticClass:
-                                                          "label label-success"
-                                                      },
-                                                      [
-                                                        _vm._v(
-                                                          "Sent on " +
-                                                            _vm._s(
-                                                              _vm.getNotificationDate(
-                                                                notification
-                                                              )
+                                                      : _c(
+                                                          "span",
+                                                          {
+                                                            staticClass:
+                                                              "label label-success"
+                                                          },
+                                                          [
+                                                            _vm._v(
+                                                              "Sent on " +
+                                                                _vm._s(
+                                                                  _vm.getNotificationDate(
+                                                                    notification
+                                                                  )
+                                                                )
                                                             )
+                                                          ]
                                                         )
-                                                      ]
-                                                    )
-                                              ]
+                                                  ]
+                                            ],
+                                            2
+                                          )
                                         ],
-                                        2
+                                        1
                                       ),
                                       _vm._v(" "),
                                       _c("p", [
@@ -989,6 +1002,8 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
+//
 
 
 
@@ -1066,6 +1081,17 @@ __webpack_require__.r(__webpack_exports__);
       var createdAt = moment(notification.createdAt).unix();
       var updatedAt = moment(notification.updatedAt).unix();
       return "".concat(id, "-").concat(createdAt, "-").concat(updatedAt);
+    },
+    getNotificationTooltip: function getNotificationTooltip(notification) {
+      if (notification.id) {
+        return "Notification ".concat(notification.id);
+      }
+
+      if (notification.job && notification.job.id) {
+        return "Job ".concat(notification.job.id);
+      }
+
+      return 'No ID found';
     },
     initialize: function initialize() {
       var _this = this;
@@ -3663,7 +3689,7 @@ var render = function() {
                                           {
                                             attrs: {
                                               title:
-                                                "This is an approximation and will depend on the user preference at the time of publish."
+                                                "This is an approximation and will depend on the user preference at the time of publish. Users who have never used the app will be excluded."
                                             }
                                           },
                                           [

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -108,7 +108,7 @@
                       Estimating...
                     </template>
                     <template v-else>
-                    Estimated: {{ matches.count }} user<template v-if="matches.count !== 1">s</template> <tooltip title="This is an approximation and will depend on the user preference at the time of publish."><i class="fa fa-info-circle"></i></tooltip>
+                    Estimated: {{ matches.count }} user<template v-if="matches.count !== 1">s</template> <tooltip title="This is an approximation and will depend on the user preference at the time of publish. Users who have never used the app will be excluded."><i class="fa fa-info-circle"></i></tooltip>
                     </template>
                   </span>
                 </p>

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -41,11 +41,13 @@
                   :data-job-id="notification.job && notification.job.id">
                   <td class="list-col-content">
                     <p>
-                      <span v-if="notification.status === 'draft'" class="label label-default">Draft</span>
-                      <template v-else>
-                        <span v-if="notification.status === 'scheduled'" class="label label-info">Scheduled for {{ getNotificationDate(notification)}}</span>
-                        <span v-else class="label label-success">Sent on {{ getNotificationDate(notification) }}</span>
-                      </template>
+                      <tooltip :title="getNotificationTooltip(notification)">
+                        <span v-if="notification.status === 'draft'" class="label label-default">Draft</span>
+                        <template v-else>
+                          <span v-if="notification.status === 'scheduled'" class="label label-info">Scheduled for {{ getNotificationDate(notification)}}</span>
+                          <span v-else class="label label-success">Sent on {{ getNotificationDate(notification) }}</span>
+                        </template>
+                      </tooltip>
                     </p>
                     <p><strong>{{ notification.data.title }}</strong><br>{{ notification.data.message }}</p>
                     <Notification-Link :notification="notification"></Notification-Link>
@@ -185,6 +187,17 @@ export default {
       const updatedAt = moment(notification.updatedAt).unix();
 
       return `${id}-${createdAt}-${updatedAt}`;
+    },
+    getNotificationTooltip(notification) {
+      if (notification.id) {
+        return `Notification ${notification.id}`;
+      }
+
+      if (notification.job && notification.job.id) {
+        return `Job ${notification.job.id}`;
+      }
+
+      return 'No ID found';
     },
     initialize() {
       return Fliplet.Pages.get().then((pages) => {


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6018

Follows #99 

![image](https://user-images.githubusercontent.com/290733/76857652-cb409800-684d-11ea-9ed7-e7e9b40798a7.png)

For some reason I added `title="Foo"` and it didn't work. I found some articles of people having difficulty getting the basics of a `<span title="Foo">` to show the tooltip.

I'm just going to use the Bootstrap Tooltip instead since it's already widely used in this UI.

![image](https://user-images.githubusercontent.com/290733/76857270-068e9700-684d-11ea-9c8a-642ab7bba984.png)
