### PR TITLE
Hides user count for notifications sent to all users (without filters)

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -532,45 +532,37 @@ var render = function() {
                                     "td",
                                     { staticClass: "list-col-sent-to" },
                                     [
-                                      _c(
-                                        "p",
-                                        [
-                                          _vm._v(
-                                            "\n                    " +
-                                              _vm._s(notification.userCount) +
-                                              " user"
-                                          ),
-                                          notification.userCount !== 1
-                                            ? [_vm._v("s")]
-                                            : _vm._e(),
-                                          _c("br"),
-                                          _vm._v(" "),
-                                          _c(
-                                            "small",
-                                            [
-                                              _vm._v("via "),
-                                              notification.type === "in-app"
-                                                ? [_vm._v("in-app")]
-                                                : _vm._e(),
-                                              _vm._v(" "),
-                                              notification.type === "in-app" &&
-                                              notification.job
-                                                ? [_vm._v("&")]
-                                                : _vm._e(),
-                                              _vm._v(" "),
-                                              notification.job ||
-                                              notification.type === "push"
-                                                ? [_vm._v("push")]
-                                                : _vm._e(),
-                                              _vm._v(
-                                                "\n                    notifications"
-                                              )
-                                            ],
-                                            2
-                                          )
-                                        ],
-                                        2
-                                      )
+                                      _c("p", [
+                                        _vm._v(
+                                          "\n                    " +
+                                            _vm._s(_vm.userCount(notification))
+                                        ),
+                                        _c("br"),
+                                        _vm._v(" "),
+                                        _c(
+                                          "small",
+                                          [
+                                            _vm._v("via "),
+                                            notification.type === "in-app"
+                                              ? [_vm._v("in-app")]
+                                              : _vm._e(),
+                                            _vm._v(" "),
+                                            notification.type === "in-app" &&
+                                            notification.job
+                                              ? [_vm._v("&")]
+                                              : _vm._e(),
+                                            _vm._v(" "),
+                                            notification.job ||
+                                            notification.type === "push"
+                                              ? [_vm._v("push")]
+                                              : _vm._e(),
+                                            _vm._v(
+                                              "\n                    notifications"
+                                            )
+                                          ],
+                                          2
+                                        )
+                                      ])
                                     ]
                                   ),
                                   _vm._v(" "),
@@ -1013,6 +1005,8 @@ __webpack_require__.r(__webpack_exports__);
 
 
 
+var defaultAudience = '';
+var defaultScope = [];
 /* harmony default export */ __webpack_exports__["default"] = ({
   data: function data() {
     return {
@@ -1101,6 +1095,21 @@ __webpack_require__.r(__webpack_exports__);
         _this.instance = Fliplet.Notifications.init();
         return _this.loadNotifications();
       });
+    },
+    userCount: function userCount(notification) {
+      if (!notification) {
+        return;
+      }
+
+      var audience = _.get(notification, 'data.audience', defaultAudience);
+
+      var scope = _.get(notification, 'scope', defaultScope);
+
+      if (!audience && _.isEmpty(scope)) {
+        return 'All users';
+      }
+
+      return "".concat(notification.userCount, " user").concat(notification.userCount !== 1 ? 's' : '');
     },
     getNotificationTimezone: function getNotificationTimezone(notification) {
       var timezone = _.get(notification, 'data._metadata.scheduledAtTimezone');

--- a/dist/app.js
+++ b/dist/app.js
@@ -4239,7 +4239,7 @@ var render = function() {
                         "h4",
                         [
                           _vm._v("Sending to\n            "),
-                          _vm.audience === ""
+                          _vm.audience === "" && !_vm.filterScopes.length
                             ? [_vm._v("all users")]
                             : [
                                 _c("strong", [

--- a/dist/app.js
+++ b/dist/app.js
@@ -3664,44 +3664,47 @@ var render = function() {
                           _vm._v(" "),
                           _c("div", { staticClass: "col-xs-4 text-right" }, [
                             _c("p", [
-                              _c(
-                                "span",
-                                { staticClass: "recipient-count" },
-                                [
-                                  _vm.loadingMatches
-                                    ? [
-                                        _vm._v(
-                                          "\n                    Estimating...\n                  "
-                                        )
-                                      ]
-                                    : [
-                                        _vm._v(
-                                          "\n                  Estimated: " +
-                                            _vm._s(_vm.matches.count) +
-                                            " user"
-                                        ),
-                                        _vm.matches.count !== 1
-                                          ? [_vm._v("s")]
-                                          : _vm._e(),
-                                        _vm._v(" "),
-                                        _c(
-                                          "tooltip",
-                                          {
-                                            attrs: {
-                                              title:
-                                                "This is an approximation and will depend on the user preference at the time of publish. Users who have never used the app will be excluded."
-                                            }
-                                          },
-                                          [
-                                            _c("i", {
-                                              staticClass: "fa fa-info-circle"
-                                            })
+                              _vm.audience !== "" || _vm.filterScopes.length
+                                ? _c(
+                                    "span",
+                                    { staticClass: "recipient-count" },
+                                    [
+                                      _vm.loadingMatches
+                                        ? [
+                                            _vm._v(
+                                              "\n                    Estimating...\n                  "
+                                            )
                                           ]
-                                        )
-                                      ]
-                                ],
-                                2
-                              )
+                                        : [
+                                            _vm._v(
+                                              "\n                  Estimated: " +
+                                                _vm._s(_vm.matches.count) +
+                                                " user"
+                                            ),
+                                            _vm.matches.count !== 1
+                                              ? [_vm._v("s")]
+                                              : _vm._e(),
+                                            _vm._v(" "),
+                                            _c(
+                                              "tooltip",
+                                              {
+                                                attrs: {
+                                                  title:
+                                                    "This is an approximation and will depend on the user preference at the time of publish. Users who have never used the app will be excluded."
+                                                }
+                                              },
+                                              [
+                                                _c("i", {
+                                                  staticClass:
+                                                    "fa fa-info-circle"
+                                                })
+                                              ]
+                                            )
+                                          ]
+                                    ],
+                                    2
+                                  )
+                                : _vm._e()
                             ])
                           ])
                         ]),
@@ -4235,19 +4238,29 @@ var render = function() {
                       _c(
                         "h4",
                         [
-                          _vm._v("Sending to "),
-                          _c("strong", [_vm._v(_vm._s(_vm.matches.count))]),
-                          _vm._v(" " + _vm._s(_vm.audienceVerbose) + " user"),
-                          _vm.matches.count !== 1 ? [_vm._v("s")] : _vm._e(),
+                          _vm._v("Sending to\n            "),
+                          _vm.audience === ""
+                            ? [_vm._v("all users")]
+                            : [
+                                _c("strong", [
+                                  _vm._v(_vm._s(_vm.matches.count))
+                                ]),
+                                _vm._v(
+                                  " " + _vm._s(_vm.audienceVerbose) + " user"
+                                ),
+                                _vm.matches.count !== 1
+                                  ? [_vm._v("s")]
+                                  : _vm._e()
+                              ],
                           _vm._v(" "),
-                          _vm.filters.length
+                          _vm.filterScopes.length
                             ? [_vm._v("matching all of the following")]
                             : _vm._e()
                         ],
                         2
                       ),
                       _vm._v(" "),
-                      _vm.filters.length
+                      _vm.filterScopes.length
                         ? [
                             _c(
                               "ul",
@@ -4399,6 +4412,12 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _Timepicker__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(55);
 /* harmony import */ var _TokenField__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(50);
 /* harmony import */ var vuejs_datepicker__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(60);
+//
+//
+//
+//
+//
+//
 //
 //
 //
@@ -5028,6 +5047,11 @@ var defaultSendLabel = 'Send notification';
       var _this2 = this;
 
       if (!this.instance) {
+        return Promise.resolve();
+      }
+
+      if (!this.audience && !this.filterScopes.length) {
+        // Don't calculate matches if it's for all users
         return Promise.resolve();
       }
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -3378,7 +3378,10 @@ var render = function() {
                                                     "a",
                                                     {
                                                       staticClass: "add-path",
-                                                      attrs: { href: "#" },
+                                                      attrs: {
+                                                        href: "#",
+                                                        tabindex: "-1"
+                                                      },
                                                       on: {
                                                         click: function(
                                                           $event

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -68,7 +68,7 @@
                   <div class="col-xs-4">
                     <p><input type="text" class="form-control" placeholder="Field name" v-model="filter.column"></p>
                     <div class="form-inline filter-path">
-                      <a v-if="!showFilterPath(filter)" class="add-path" href="#" @click.prevent="addFilterPath(filter)">This field is an object</a>
+                      <a v-if="!showFilterPath(filter)" class="add-path" href="#" @click.prevent="addFilterPath(filter)" tabindex="-1">This field is an object</a>
                       <div v-else class="form-group">
                         <label class="filter-path-label">Path</label>
                         <input type="text" class="form-control" placeholder="e.g. companies[0].name" v-model="filter.path">

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -221,7 +221,7 @@
               </div>
             </div>
             <h4>Sending to
-              <template v-if="audience === ''">all users</template>
+              <template v-if="audience === '' && !filterScopes.length">all users</template>
               <template v-else>
                 <strong>{{ matches.count }}</strong> {{ audienceVerbose }} user<template v-if="matches.count !== 1">s</template>
               </template>

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -103,7 +103,7 @@
               </div>
               <div class="col-xs-4 text-right">
                 <p>
-                  <span class="recipient-count">
+                  <span class="recipient-count" v-if="audience !== '' || filterScopes.length">
                     <template v-if="loadingMatches">
                       Estimating...
                     </template>
@@ -220,8 +220,14 @@
                 </div>
               </div>
             </div>
-            <h4>Sending to <strong>{{ matches.count }}</strong> {{ audienceVerbose }} user<template v-if="matches.count !== 1">s</template> <template v-if="filters.length">matching all of the following</template></h4>
-            <template v-if="filters.length">
+            <h4>Sending to
+              <template v-if="audience === ''">all users</template>
+              <template v-else>
+                <strong>{{ matches.count }}</strong> {{ audienceVerbose }} user<template v-if="matches.count !== 1">s</template>
+              </template>
+              <template v-if="filterScopes.length">matching all of the following</template>
+            </h4>
+            <template v-if="filterScopes.length">
               <ul class="filter-summary-items">
                 <li v-for="(filter, index) in filters" :key="index" v-html="getFilterVerbose(filter)"></li>
               </ul>
@@ -624,6 +630,11 @@ export default {
     },
     getMatches() {
       if (!this.instance) {
+        return Promise.resolve();
+      }
+
+      if (!this.audience && !this.filterScopes.length) {
+        // Don't calculate matches if it's for all users
         return Promise.resolve();
       }
 

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -55,7 +55,7 @@
                   <td class="list-col-notes"><Notification-Notes :notification.sync="notification"></Notification-Notes></td>
                   <td class="list-col-sent-to">
                     <p>
-                      {{ notification.userCount }} user<template v-if="notification.userCount !== 1">s</template><br>
+                      {{ userCount(notification) }}<br>
                       <small>via <template v-if="notification.type === 'in-app'">in-app</template>
                       <template v-if="notification.type === 'in-app' && notification.job">&amp;</template>
                       <template v-if="notification.job || notification.type === 'push'">push</template>
@@ -117,6 +117,9 @@ import {
   getOffsetString as getTimezoneOffsetString,
   validate as validateTimezone
 } from '../libs/timezones';
+
+const defaultAudience = '';
+const defaultScope = [];
 
 export default {
   data() {
@@ -206,6 +209,20 @@ export default {
         this.instance = Fliplet.Notifications.init();
         return this.loadNotifications();
       });
+    },
+    userCount(notification) {
+      if (!notification) {
+        return;
+      }
+
+      const audience = _.get(notification, 'data.audience', defaultAudience);
+      const scope = _.get(notification, 'scope', defaultScope);
+
+      if (!audience && _.isEmpty(scope)) {
+        return 'All users';
+      }
+
+      return `${notification.userCount} user${notification.userCount !== 1 ? 's' : ''}`;
     },
     getNotificationTimezone(notification) {
       const timezone = _.get(notification, 'data._metadata.scheduledAtTimezone');


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6153

Also skips object path toggle link when tabbing.

## All users (without filters)

**Create**

![image](https://user-images.githubusercontent.com/290733/77936878-6d7b6980-72ab-11ea-9495-db268d92f92b.png)

**Review**

![image](https://user-images.githubusercontent.com/290733/77937065-b29f9b80-72ab-11ea-8b11-25dfe3a2efbb.png)

## All users (with filters)

**Create**

![image](https://user-images.githubusercontent.com/290733/77936984-956acd00-72ab-11ea-842d-864c76c70e7c.png)

**Review**

![image](https://user-images.githubusercontent.com/290733/77937199-e7abee00-72ab-11ea-8d91-c0ab95c78995.png)

## List view

Notifications sent to all users (without filters) will be shown as "All users".

![image](https://user-images.githubusercontent.com/290733/77941942-da463200-72b2-11ea-9690-13f8a91ec0d3.png)
