### PR TITLE
ID-99 [Fix] Updates background notification to use HTML Toast UI

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -122,11 +122,11 @@ Fliplet.Widget.register('PushNotifications', function () {
       title: data.title,
       message: data.message,
       onClick: function () {
-        if (!data.additionalData) {
+        if (!data.additionalData || !data.additionalData.customData) {
           return;
         }
 
-        Fliplet.Native.Notifications.handle(data.additionalData.customData)
+        Fliplet.Native.Notifications.handle(data.additionalData.customData);
       }
     });
   }

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -117,14 +117,18 @@ Fliplet.Widget.register('PushNotifications', function () {
   }
 
   function handleForegroundNotification(data) {
-    Fliplet.Navigator.Notifications.schedule({
+    Fliplet.UI.Toast({
+      type: 'regular',
       title: data.title,
-      text: data.message,
-      foreground: true,
-      data: data.additionalData
-    }, function () {
-      // notification has been scheduled
-    }, this, { skipPermission: true });
+      message: data.message,
+      onClick: function () {
+        if (!data.additionalData) {
+          return;
+        }
+
+        Fliplet.Native.Notifications.handle(data.additionalData.customData)
+      }
+    });
   }
 
   function ask(options) {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-99

Requires https://github.com/Fliplet/fliplet-api/pull/4311

Changes foreground notification behaviour to display Fliplet Toast UI instead of scheduling a local notification to be displayed immediately, which appears to cause push notifications to disappear after 5 seconds in some scenarios.