### PR TITLE
ID-99 [Fix] Ensure register works right after subscribe

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -44,8 +44,12 @@ Fliplet.Widget.register('PushNotifications', function () {
     return Fliplet.Storage.set(key, val + '-' + Date.now());
   }
 
+  /**
+   * Inits the push subscription service so incoming notifications are handled.
+   * @param {*} subscriptionDetails - Object with { id, token } or just the ID string depending on the caller
+   */
   function initPushNotifications(subscriptionDetails) {
-    var subscriptionId = subscriptionDetails.id;
+    var subscriptionId = subscriptionDetails.id || subscriptionDetails;
 
     /**
      * if we have subscribed successfully, get the push notification instance


### PR DESCRIPTION
I have found a small edge case where right after subscribing for the code responsible for handling incoming messages is not registered until you navigate to a new screen.

This also made debugging complex as I can't set breakpoints right after subscribing to debug code.