### PR TITLE
[Fix] Removes empty line when either notification title or message is missing

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -497,7 +497,10 @@ var render = function() {
                                             _vm._s(notification.data.title)
                                           )
                                         ]),
-                                        _c("br"),
+                                        notification.data.title &&
+                                        notification.data.message
+                                          ? _c("br")
+                                          : _vm._e(),
                                         _vm._v(
                                           _vm._s(notification.data.message)
                                         )

--- a/dist/app.js
+++ b/dist/app.js
@@ -492,17 +492,22 @@ var render = function() {
                                       ),
                                       _vm._v(" "),
                                       _c("p", [
-                                        _c("strong", [
-                                          _vm._v(
-                                            _vm._s(notification.data.title)
-                                          )
-                                        ]),
+                                        notification.data.title
+                                          ? _c("strong", [
+                                              _vm._v(
+                                                _vm._s(notification.data.title)
+                                              )
+                                            ])
+                                          : _vm._e(),
+                                        _vm._v(" "),
                                         notification.data.title &&
                                         notification.data.message
                                           ? _c("br")
                                           : _vm._e(),
                                         _vm._v(
-                                          _vm._s(notification.data.message)
+                                          "\n                    " +
+                                            _vm._s(notification.data.message) +
+                                            "\n                  "
                                         )
                                       ]),
                                       _vm._v(" "),
@@ -895,6 +900,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _libs_bus__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(25);
 /* harmony import */ var _libs_date__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(37);
 /* harmony import */ var _libs_timezones__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(38);
+//
+//
+//
+//
 //
 //
 //

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -49,7 +49,7 @@
                         </template>
                       </tooltip>
                     </p>
-                    <p><strong>{{ notification.data.title }}</strong><br>{{ notification.data.message }}</p>
+                    <p><strong>{{ notification.data.title }}</strong><br v-if="notification.data.title && notification.data.message">{{ notification.data.message }}</p>
                     <Notification-Link :notification="notification"></Notification-Link>
                   </td>
                   <td class="list-col-notes"><Notification-Notes :notification.sync="notification"></Notification-Notes></td>

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -49,7 +49,11 @@
                         </template>
                       </tooltip>
                     </p>
-                    <p><strong>{{ notification.data.title }}</strong><br v-if="notification.data.title && notification.data.message">{{ notification.data.message }}</p>
+                    <p>
+                      <strong v-if="notification.data.title">{{ notification.data.title }}</strong>
+                      <br v-if="notification.data.title && notification.data.message">
+                      {{ notification.data.message }}
+                    </p>
                     <Notification-Link :notification="notification"></Notification-Link>
                   </td>
                   <td class="list-col-notes"><Notification-Notes :notification.sync="notification"></Notification-Notes></td>


### PR DESCRIPTION
An empty line is added when a notification is missing a notification title or message (see the pink boxes highlighted below). This PR fixes the issue by only adding the `<br>` if both the notification title and message are present.

![image](https://user-images.githubusercontent.com/290733/102233089-c6e20200-3ee7-11eb-9af7-183085a366a4.png)
