### PR TITLE
CSD-447 [Chore] Always display notifications as configured

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -25,7 +25,7 @@ Fliplet.Widget.register('PushNotifications', function () {
 
   function isConfigured() {
     return (Fliplet.Env.is('web') && Modernizr.pushnotification)
-      || (Fliplet.Env.is('native') && (data && (data.apn || data.gcm || data.wns)));
+      || (Fliplet.Env.is('native'));
   }
 
   if (!data || !isConfigured()) {


### PR DESCRIPTION
As notifications are now available via debug apps (and soon Fliplet Viewer) we shouldn't be checking for whether they have been configured in the component settings.

Ideally, we would return `true` when running on a debug app or FV, but we don't have such information for the former as far as I know.

---

**[The warning will still be displayed in the Studio UI](https://github.com/Fliplet/fliplet-widget-push-notifications/blob/5516b41c03b4d3698d293c96201e66b05303f480/src/components/NotificationForm.vue#L170-L170) at the time of sending, which is great because it's mostly targeted at clients when sending notifications to live apps.**