### PR TITLE
OD-366 [Fix] Scroll overlay to the top when moving between notification creation steps

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -4085,7 +4085,6 @@ var render = function() {
                       expression: "steps[step].name === 'review'"
                     }
                   ],
-                  ref: "review",
                   staticClass: "row notification-review"
                 },
                 [

--- a/dist/app.js
+++ b/dist/app.js
@@ -4085,6 +4085,7 @@ var render = function() {
                       expression: "steps[step].name === 'review'"
                     }
                   ],
+                  ref: "review",
                   staticClass: "row notification-review"
                 },
                 [
@@ -4970,6 +4971,7 @@ var defaultSendLabel = 'Send notification';
     },
     step: function step() {
       this.autosize();
+      document.documentElement.scrollTop = 0;
     },
     schedule: function schedule() {
       this.autosize();

--- a/dist/app.js
+++ b/dist/app.js
@@ -4970,7 +4970,9 @@ var defaultSendLabel = 'Send notification';
     },
     step: function step() {
       this.autosize();
-      document.documentElement.scrollTop = 0;
+      Fliplet.Studio.emit('overlay-scroll-top', {
+        name: 'notifications'
+      });
     },
     schedule: function schedule() {
       this.autosize();

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -181,7 +181,7 @@
             </div>
           </div>
         </template>
-        <div class="row notification-review" v-show="steps[step].name === 'review'">
+        <div class="row notification-review" v-show="steps[step].name === 'review'" ref="review">
           <div class="col-md-10 col-md-offset-1">
             <h3>Your notification</h3>
             <template v-if="notificationHasChannel('in-app')">
@@ -500,6 +500,7 @@ export default {
     },
     step() {
       this.autosize();
+      document.documentElement.scrollTop = 0;
     },
     schedule() {
       this.autosize();

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -500,7 +500,7 @@ export default {
     },
     step() {
       this.autosize();
-      document.documentElement.scrollTop = 0;
+      Fliplet.Studio.emit('overlay-scroll-top', { name: 'notifications' });
     },
     schedule() {
       this.autosize();

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -181,7 +181,7 @@
             </div>
           </div>
         </template>
-        <div class="row notification-review" v-show="steps[step].name === 'review'" ref="review">
+        <div class="row notification-review" v-show="steps[step].name === 'review'">
           <div class="col-md-10 col-md-offset-1">
             <h3>Your notification</h3>
             <template v-if="notificationHasChannel('in-app')">


### PR DESCRIPTION
@romanyosyfiv

OD-366 https://weboo.atlassian.net/browse/OD-366

## Description
**Problem**: Overlay scroll position stayed the same
**Solution**: With each step, the document scrolls to top

## Screenshots/screencasts


https://user-images.githubusercontent.com/86256215/160583843-9810b0be-d33d-4da9-9b76-1f1275529777.mp4


## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko