### PR TITLE
PERS-106 [Fix] Ensured updated push notification setup links for iOS & android

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -3988,7 +3988,7 @@ var render = function() {
                                 {
                                   attrs: {
                                     href:
-                                      "https://help.fliplet.com/configure-push-notifications-for-ios/",
+                                      "https://help.fliplet.com/push-notifications/#1",
                                     target: "_blank"
                                   }
                                 },
@@ -4000,7 +4000,7 @@ var render = function() {
                                 {
                                   attrs: {
                                     href:
-                                      "https://help.fliplet.com/configure-push-notifications-for-android/",
+                                      "https://help.fliplet.com/push-notifications/#2",
                                     target: "_blank"
                                   }
                                 },

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -167,7 +167,7 @@
                 <span class="tab tab-checked" :class="{ 'active': notificationHasChannel('push') }" @click="toggleNotificationChannel('push')">Push notification</span>
               </div>
               <div class="alert alert-info"><strong>New!</strong> Web apps can now receive push notifications.</div>
-              <div class="alert alert-warning" v-if="!pushIsConfigured">To send push notifications to your native app, you must configure push notifications on <a href="https://help.fliplet.com/configure-push-notifications-for-ios/" target="_blank">iOS</a> and <a href="https://help.fliplet.com/configure-push-notifications-for-android/" target="_blank">Android</a>.</div>
+              <div class="alert alert-warning" v-if="!pushIsConfigured">To send push notifications to your native app, you must configure push notifications on <a href="https://help.fliplet.com/push-notifications/#1" target="_blank">iOS</a> and <a href="https://help.fliplet.com/push-notifications/#2" target="_blank">Android</a>.</div>
               <p class="text-center text-danger" v-if="errors.channels">{{ errors.channels }}</p>
             </div>
           </div>


### PR DESCRIPTION
### Product areas affected

fliplet-widget-push-notification > NotificationForm.vue

### What does this PR do?

updated the setup link which redirects to the new help section of setup notification for iOS & Android

### JIRA ticket

[PERS-106](https://weboo.atlassian.net/browse/PERS-106)

### Result

![PERS-106](https://user-images.githubusercontent.com/103016060/165061317-421b9d86-0d2e-4ec9-a50b-4e18b46b456e.jpg)

### Checklist

None

### Testing instructions

None

### Deployment instructions

None

### Deployment instructions

None