### PR TITLE
PS-1221 [FIX] Ensures Notifications pop-up doesn't appear when generating screenshots.

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -136,6 +136,11 @@ Fliplet.Widget.register('PushNotifications', function () {
   }
 
   function ask(options) {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('headless')) {
+      return;
+    }
+
     options = options || {};
 
     if (!data || !isConfigured()) {

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -137,6 +137,7 @@ Fliplet.Widget.register('PushNotifications', function () {
 
   function ask(options) {
     const params = new URLSearchParams(window.location.search);
+
     if (params.has('headless')) {
       return;
     }


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Push Notifications

### What does this PR do?

Ensures Notifications pop-up doesn't appear when generating screenshots.

### JIRA tickets

[PS-1221](https://weboo.atlassian.net/browse/PS-1221)

[PS-1221]: https://weboo.atlassian.net/browse/PS-1221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Suppresses the push notification permission prompt when a headless flag is present in the page URL, ensuring automated or headless sessions proceed without interruption. Normal browsing behaviour remains unchanged, with prompts shown as before. Improves reliability for CI/testing and embedded integrations by avoiding unexpected pop-ups. No changes to public interfaces or user-configurable settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->