### PR TITLE
PR-74 [Fix] Ensure push pop up is not shown in sub app

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -165,6 +165,15 @@ Fliplet.Widget.register('PushNotifications', function () {
     // Wait for pageView hooks before asking. This ensures that when pageView hooks navigate away
     // from the page we don't display the push notifications popup.
     askPromise = waitForPageViewHooks.then(function () {
+      return Fliplet.App.Storage.get('fl_portal_redirect');
+    }).then(function (inPortal) {
+      if (data.showOnceOnPortal && inPortal) {
+        return Promise.reject({
+          code: 5,
+          message: 'Push notifications are not shown in portal apps when showOnceOnPortal is enabled.'
+        });
+      }
+
       return Fliplet.Storage.get(key);
     }).then(function (alreadyShown) {
       // When forced by the UI we skip the popup and also mark it as seen


### PR DESCRIPTION
### What does this PR do?
This PR ensures that when user has checked to not show popup in a sub-portal app, then push pop-up should not be shown.

### JIRA Ticket
[PR-74](https://weboo.atlassian.net/browse/PR-74)

[PR-74]: https://weboo.atlassian.net/browse/PR-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Push notification prompts are now portal-aware. When configured to show only once on portal, the ask flow is gated so prompts are suppressed within portal apps.
  - Introduces a clear rejection outcome when prompts are intentionally suppressed in portal contexts, improving user experience consistency.

- Tests
  - Existing behaviour for showing prompts and handling user interactions remains unchanged outside portal-gated scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->