### PR TITLE
Update push notification wording

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -3938,30 +3938,19 @@ var render = function () {
                         !_vm.pushIsConfigured
                           ? _c("div", { staticClass: "alert alert-warning" }, [
                               _vm._v(
-                                "To send push notifications to your native app, you must configure push notifications on "
+                                "To send notifications to your native apps, you must first "
                               ),
                               _c(
                                 "a",
                                 {
                                   attrs: {
-                                    href: "https://help.fliplet.com/configure-push-notifications-for-ios/",
+                                    href: "https://help.fliplet.com/push-notifications/",
                                     target: "_blank",
                                   },
                                 },
-                                [_vm._v("iOS")]
+                                [_vm._v("configure")]
                               ),
-                              _vm._v(" and "),
-                              _c(
-                                "a",
-                                {
-                                  attrs: {
-                                    href: "https://help.fliplet.com/configure-push-notifications-for-android/",
-                                    target: "_blank",
-                                  },
-                                },
-                                [_vm._v("Android")]
-                              ),
-                              _vm._v("."),
+                              _vm._v(" push notifications."),
                             ])
                           : _vm._e(),
                         _vm._v(" "),

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -168,7 +168,7 @@
                 <span class="tab tab-checked" :class="{ 'active': notificationHasChannel('push') }" @click="toggleNotificationChannel('push')">Push notification</span>
               </div>
               <div class="alert alert-info"><strong>New!</strong> Web apps can now receive push notifications.</div>
-              <div class="alert alert-warning" v-if="!pushIsConfigured">To send push notifications to your native app, you must configure push notifications on <a href="https://help.fliplet.com/configure-push-notifications-for-ios/" target="_blank">iOS</a> and <a href="https://help.fliplet.com/configure-push-notifications-for-android/" target="_blank">Android</a>.</div>
+              <div class="alert alert-warning" v-if="!pushIsConfigured">To send notifications to your native apps, you must first <a href="https://help.fliplet.com/push-notifications/" target="_blank">configure</a> push notifications.</div>
               <p class="text-center text-danger" v-if="errors.channels">{{ errors.channels }}</p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Updates the push notification warning message wording
- Changes from "To send push notifications to your native app, you must configure push notifications on iOS and Android." to "To send notifications to your native apps, you must first configure push notifications."
- Consolidates the iOS and Android links into a single "configure" link pointing to https://help.fliplet.com/push-notifications/

## Test plan
- [ ] Open the push notifications widget in Studio
- [ ] Verify the warning message displays the new wording when push is not configured
- [ ] Verify the "configure" link opens https://help.fliplet.com/push-notifications/

**JIRA:** [PS-1692](https://weboo.atlassian.net/browse/PS-1692)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PS-1692]: https://weboo.atlassian.net/browse/PS-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ