### PR TITLE
[SEC-9] Expand excludedProperties to prevent exposure of sensitive push notification keys

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -9,7 +9,17 @@
   "references": [],
   "html_tag": "div",
   "settings": {
-    "excludedProperties": ["apnKeyId", "apnTeamId", "apnAuthKey", "gcmProjectId", "gcmServerKey"]
+    "excludedProperties": [
+      "apnKeyId",
+      "apnTeamId",
+      "apnAuthKey",
+      "gcmProjectId",
+      "gcmServerKey",
+      "private_key",
+      "client_email",
+      "project_id",
+      "gcmSenderId"
+    ]
   },
   "interface": {
     "dependencies": [


### PR DESCRIPTION
### Product areas affected
Widget configuration (`widget.json`) — affects how push notification settings are exposed across all platforms.

### What does this PR do?
Adds `private_key`, `client_email`, `project_id`, and `gcmSenderId` to the `excludedProperties` list in `widget.json` to prevent these sensitive push notification credentials from being exposed publicly.

### JIRA ticket
[SEC-9](https://weboo.atlassian.net/browse/SEC-9)

### Result
The `settings.excludedProperties` array now includes 9 keys (up from 5), ensuring that all sensitive APNs/GCM/FCM credentials are excluded from public access.

### Checklist
 - [ ] Added automated test coverage as appropriate for this change.

### Deployment instructions
No special deployment steps required. The updated `widget.json` will take effect on next widget publish.

### Author concerns
None — this is a straightforward configuration change with no code logic modifications.

[SEC-9]: https://weboo.atlassian.net/browse/SEC-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ