### PR TITLE
fix(push-notifications): detect token rotation before registration event fires (DEV-965)

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -69,7 +69,13 @@ Fliplet.Widget.register('PushNotifications', function () {
             : undefined;
 
           if (currentToken && currentToken !== subscriptionDetails.token) {
-            Fliplet.User.updateSubscription({ token: currentToken });
+            console.info('[push] OS token rotated since last registration — updating subscription');
+            Fliplet.User.updateSubscription({ token: currentToken }).catch(function (err) {
+              console.warn('[push] immediate token update failed', err);
+            });
+            // Update the cached token so the listener below doesn't fire a redundant
+            // updateSubscription if the plugin re-emits 'registration' with the same value.
+            subscriptionDetails.token = currentToken;
           }
 
           // Retain the event listener as a fallback for token rotation mid-session
@@ -81,7 +87,10 @@ Fliplet.Widget.register('PushNotifications', function () {
             // update subscription with new token
             Fliplet.User.updateSubscription({
               token: data.registrationId
+            }).catch(function (err) {
+              console.warn('[push] mid-session token update failed', err);
             });
+            subscriptionDetails.token = data.registrationId;
           });
         }
 

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -60,6 +60,19 @@ Fliplet.Widget.register('PushNotifications', function () {
     if (push) {
       if (subscriptionId) {
         if (subscriptionDetails.token) {
+          // Immediate check: the Cordova plugin fires the 'registration' event very early
+          // at app launch, often before this listener is attached. If registrationId was
+          // already captured by getPushNotificationInstance(), compare it now so we don't
+          // miss a token rotation that happened before this point.
+          var currentToken = typeof Fliplet.User.getRegistrationId === 'function'
+            ? Fliplet.User.getRegistrationId()
+            : undefined;
+
+          if (currentToken && currentToken !== subscriptionDetails.token) {
+            Fliplet.User.updateSubscription({ token: currentToken });
+          }
+
+          // Retain the event listener as a fallback for token rotation mid-session
           push.on('registration', function (data) {
             if (data.registrationId === subscriptionDetails.token) {
               return; // token hasn't changed


### PR DESCRIPTION
## Summary

- `initPushNotifications()` now performs an immediate token comparison using `Fliplet.User.getRegistrationId()` alongside the existing `'registration'` event listener.
- This catches push token rotations that occurred before the listener was attached — the Cordova plugin fires the registration event very early at app launch, often before widget code runs, causing the comparison to be silently missed.

## Context

Part of DEV-965. The server-side and `fliplet-core` changes are in the companion PR: Fliplet/fliplet-api#7901

## Test plan

- [ ] Simulate token rotation (change stored localStorage token to a stale value) → re-launch app → verify `updateSubscription()` is called immediately without waiting for a new registration event
- [ ] Normal flow (token unchanged) → verify no spurious `updateSubscription()` call is made
- [ ] Regression: existing push notification delivery and permission flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)