### PR TITLE
fix(push-notifications): detect web token rotation at launch (DEV-965)

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -72,6 +72,11 @@ Fliplet.Widget.register('PushNotifications', function () {
         return Fliplet.User.updateSubscription({ token: currentToken }).catch(function (err) {
           console.warn('[push] web token update failed', err);
         });
+      }).catch(function (err) {
+        // Defensive outer catch: if fliplet-core's getCurrentWebPushToken contract
+        // ever changes to reject (it currently swallows internally), don't leak an
+        // UnhandledPromiseRejection.
+        console.warn('[push] web token rotation check failed', err);
       });
     }
 

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -57,6 +57,24 @@ Fliplet.Widget.register('PushNotifications', function () {
      */
     var push = Fliplet.User.getPushNotificationInstance(data);
 
+    if (!push && Fliplet.Env.is('web') && subscriptionId && subscriptionDetails.token
+        && typeof Fliplet.User.getCurrentWebPushToken === 'function') {
+      // Web has no Cordova plugin firing a 'registration' event, so instead read
+      // the live SW push subscription once at launch and update the server-side
+      // subscription if the cached token differs from the current browser endpoint.
+      Fliplet.User.getCurrentWebPushToken().then(function (currentToken) {
+        if (!currentToken || currentToken === subscriptionDetails.token) {
+          return;
+        }
+
+        console.info('[push] Web push subscription has rotated since last registration — updating subscription');
+
+        return Fliplet.User.updateSubscription({ token: currentToken }).catch(function (err) {
+          console.warn('[push] web token update failed', err);
+        });
+      });
+    }
+
     if (push) {
       if (subscriptionId) {
         if (subscriptionDetails.token) {


### PR DESCRIPTION
## Summary

Adds a web-only branch in `initPushNotifications()` that reads the live service-worker push subscription via `Fliplet.User.getCurrentWebPushToken()` (companion API PR Fliplet/fliplet-api#8058) and calls `updateSubscription()` if the cached token differs.

## Context

QA (Inna, 2026-05-01) flagged that test plan **TC 2.1** fails on web: editing the cached `push-token-<appId>` value in localStorage and refreshing the page produces no `/v1/subscriptions` request. The previous DEV-965 work (PR #222) covered the native early-event race but missed the web path entirely.

The widget's launch flow (`js/notifications.js:279-291`) only calls `initPushNotifications(details)` when cached details exist — never `subscribe()` — so the rotation check inside `subscribe()` doesn't run on launch. Inside `initPushNotifications()`, the existing rotation logic sits inside `if (push)` which is always falsy on web (`Fliplet.User.getPushNotificationInstance()` returns undefined when the Cordova plugin global is missing).

## Implementation

New branch sits next to the existing native check:

- Fires when no Cordova `push` instance is available AND we're on web AND we have a cached subscription with a token.
- Feature-detects `Fliplet.User.getCurrentWebPushToken` so older `fliplet-core` versions are safe.
- Compares the cached token (JSON string) against the live SW subscription (`JSON.stringify(pushSubscription.toJSON())`) and fires `updateSubscription({ token })` on mismatch.
- `updateSubscription` already handles 404 by clearing local storage (`fliplet-core`'s existing behavior), so server-side deletion is also caught when it coincides with rotation.

## Test plan

- [ ] TC 2.1 (Chrome): edit `push-token-<appId>` in localStorage → refresh → DevTools Network shows `PUT /v1/apps/<appId>/subscriptions/<id>` within seconds
- [ ] TC 1.1 / 1.4 regression: first-time permission grant + send + receive still works on web
- [ ] Native (iOS/Android): unchanged — existing `getRegistrationId()` immediate check still runs inside `if (push)`
- [ ] App with older `fliplet-core` (no `getCurrentWebPushToken`): feature-detect skips the branch, no errors

## Companion PR

API method exposed by: Fliplet/fliplet-api#8058