### PR TITLE
feat: rename apps → projects (v3 user-visible wording)

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -3,7 +3,7 @@
   <div id="settings">
     <p class="text-right"><a href="#" class="btn btn-default exit-settings">Back</a></p>
     <h4 class="custom-h4">Instructions</h4>
-    <p>Push notifications require a user to subscribe. In order to subscribe a user to push notifications please configure the following settings. After updating these settings you will need to publish your app.</p>
+    <p>Push notifications require a user to subscribe. In order to subscribe a user to push notifications please configure the following settings. After updating these settings you will need to publish your project.</p>
     <p><strong>Note:</strong> You cannot use or test this feature in Fliplet Viewer. It will only work in live apps with the relevant operating system push notification settings configured. Push does not work on web apps.</p>
     <h4 class="custom-h4">Push request interface</h4>
     <p>Configure the settings for the notification interface that will ask the user if they want to enable push notifications.</p>
@@ -28,7 +28,7 @@
         </div>
         <div class="form-group clearfix">
           <div class="col-sm-12 control-label">
-            <label for="auto-popup">Do you want to show the push notification permission popup automatically on the first screen of the app?</label>
+            <label for="auto-popup">Do you want to show the push notification permission popup automatically on the first screen of the project?</label>
           </div>
           <div class="col-sm-12">
             <div class="checkbox checkbox-icon">
@@ -53,7 +53,7 @@ pushWidget.ask().then(function (subscriptionId) {
             <div class="checkbox checkbox-icon">
               <input type="checkbox" id="portal-popup" name="showOnceOnPortal" value="1" {{#if showOnceOnPortal}}checked{{/if}} />
               <label for="portal-popup">
-                <span class="check"><i class="fa fa-check"></i></span> Apps inside a portal shouldn't request users to subscribe to push notifications.
+                <span class="check"><i class="fa fa-check"></i></span> Projects inside a portal shouldn't request users to subscribe to push notifications.
               </label>
             </div>
           </div>

--- a/src/components/NotificationForm.vue
+++ b/src/components/NotificationForm.vue
@@ -111,7 +111,7 @@
                     </template>
                     <template v-else>
                       Estimated: {{ matches.count }} user<template v-if="matches.count !== 1">s</template>
-                      <tooltip title="This is an approximation and will depend on the user preference at the time of publish. Users who have never used the app will be excluded."><i class="fa fa-info-circle"></i></tooltip>
+                      <tooltip title="This is an approximation and will depend on the user preference at the time of publish. Users who have never used the project will be excluded."><i class="fa fa-info-circle"></i></tooltip>
                     </template>
                   </span>
                 </p>

--- a/src/components/NotificationList.vue
+++ b/src/components/NotificationList.vue
@@ -18,7 +18,7 @@
           <template v-if="!notifications.length">
             <div class="notifications-empty">
               <h4>Send a notification</h4>
-              <p>Communicate latest updates and promotions with your users so they can re-engage with your app.</p>
+              <p>Communicate latest updates and promotions with your users so they can re-engage with your project.</p>
             </div>
           </template>
           <template v-else>


### PR DESCRIPTION
## Summary

Replaces #224 with a clean branch based directly on `production`. Same rename, but without the unrelated master-only commits (DEV-654 lodash removal, PR-24 filter add + revert) that were pulled in by the previous branch.

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518. Conservative pass — most "app" references here are platform deliverable terminology (iOS / Android / web app) and runtime end-user popup copy, which all stay as "app". Only 4 Studio-editor surfaces renamed.

## Scope (5 strings across 3 files)

- `interface.html:6`: "publish your app" → "publish your project"
- `interface.html:31`: "first screen of the app" → "first screen of the project"
- `interface.html:56`: "Apps inside a portal" → "Projects inside a portal"
- `src/components/NotificationList.vue:21`: "re-engage with your app" → "re-engage with your project"
- `src/components/NotificationForm.vue:114`: "Users who have never used the app" → "Users who have never used the project"

## What was kept (platform / runtime / proper-noun)

- "Push does not work on web apps" — platform deliverable type
- "your native app" / "Web apps can now receive push" — platform deliverable
- "About this app" (NotificationForm) — literal Fliplet Viewer screen label
- Runtime end-user popup defaults ("App updates and notifications", "app updates are available") in `build.html` + `translation.json`
- "live apps with the relevant operating system" — platform deliverable
- "the app might be uninstalled" (NotificationList) — runtime native app

## What was kept (internal)

- CSS classes (`.app-icon-preview`, `.app-name`, `.settings-saved-app-msg`)
- JS vars (`appIcon`, `appName` from `Fliplet.Env.get('appName')`)
- Channel identifier `'in-app'` (logic value)
- File path `'img/app-icon.png'`
- API route `'v1/apps/tokens'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)