### PR TITLE
chore(DEV-1297): rebuild dist after rename to projects

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -143,10 +143,10 @@ component.options.__file = "src/Application.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Application_vue_vue_type_template_id_44b1e432__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Application_vue_vue_type_template_id_44b1e432__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Application_vue_vue_type_template_id_44b1e432__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(3);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Application_vue_vue_type_template_id_44b1e432__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Application_vue_vue_type_template_id_44b1e432__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Application_vue_vue_type_template_id_44b1e432__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -158,22 +158,33 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "notifications-container"
-  }, [_c("Notification-List", {
-    directives: [{
-      name: "show",
-      rawName: "v-show",
-      value: _vm.view === "list",
-      expression: "view === 'list'"
-    }]
-  }), _vm._v(" "), _vm.view === "form" ? _c("Notification-Form") : _vm._e()], 1);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "div",
+    { staticClass: "notifications-container" },
+    [
+      _c("Notification-List", {
+        directives: [
+          {
+            name: "show",
+            rawName: "v-show",
+            value: _vm.view === "list",
+            expression: "view === 'list'",
+          },
+        ],
+      }),
+      _vm._v(" "),
+      _vm.view === "form" ? _c("Notification-Form") : _vm._e(),
+    ],
+    1
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -195,6 +206,14 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _components_NotificationForm__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(39);
 /* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(16);
 /* harmony import */ var _libs_bus__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(25);
+//
+//
+//
+//
+//
+//
+//
+
 
 
 
@@ -270,10 +289,10 @@ component.options.__file = "src/components/NotificationList.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationList_vue_vue_type_template_id_93ede84e__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(8);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationList_vue_vue_type_template_id_93ede84e__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationList_vue_vue_type_template_id_93ede84e__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(8);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationList_vue_vue_type_template_id_93ede84e__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationList_vue_vue_type_template_id_93ede84e__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationList_vue_vue_type_template_id_93ede84e__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -285,270 +304,583 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "container-fluid"
-  }, [_c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-xs-6"
-  }, [_c("p", [_c("a", {
-    staticClass: "btn btn-primary",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.createNotification.apply(null, arguments);
-      }
-    }
-  }, [_c("i", {
-    staticClass: "fa fa-fw fa-lg fa-plus"
-  }), _vm._v(" Create new")])])]), _vm._v(" "), _vm._m(0)]), _vm._v(" "), _c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-xs-12"
-  }, [_vm.isLoading ? _c("div", {
-    staticClass: "notifications-loading spinner-holder animated"
-  }, [_c("div", {
-    staticClass: "spinner-overlay"
-  }), _vm._v(" "), _c("p", [_vm._v("Loading notifications")])]) : [!_vm.notifications.length ? [_vm._m(1)] : [_c("div", {
-    staticClass: "checkbox checkbox-icon"
-  }, [_c("input", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.showTimezone,
-      expression: "showTimezone"
-    }],
-    attrs: {
-      id: "show-timezone",
-      type: "checkbox"
-    },
-    domProps: {
-      checked: Array.isArray(_vm.showTimezone) ? _vm._i(_vm.showTimezone, null) > -1 : _vm.showTimezone
-    },
-    on: {
-      change: function change($event) {
-        var $$a = _vm.showTimezone,
-          $$el = $event.target,
-          $$c = $$el.checked ? true : false;
-        if (Array.isArray($$a)) {
-          var $$v = null,
-            $$i = _vm._i($$a, $$v);
-          if ($$el.checked) {
-            $$i < 0 && (_vm.showTimezone = $$a.concat([$$v]));
-          } else {
-            $$i > -1 && (_vm.showTimezone = $$a.slice(0, $$i).concat($$a.slice($$i + 1)));
-          }
-        } else {
-          _vm.showTimezone = $$c;
-        }
-      }
-    }
-  }), _vm._v(" "), _vm._m(2)]), _vm._v(" "), _c("table", {
-    staticClass: "table table-condensed notification-list"
-  }, [_vm._m(3), _vm._v(" "), _c("tbody", _vm._l(_vm.notifications, function (notification) {
-    return _c("tr", {
-      key: _vm.getNotificationKey(notification),
-      attrs: {
-        "data-notification-id": notification.id,
-        "data-job-id": notification.job && notification.job.id
-      }
-    }, [_c("td", {
-      staticClass: "list-col-content"
-    }, [_c("p", [_c("tooltip", {
-      attrs: {
-        title: _vm.getNotificationTooltip(notification)
-      }
-    }, [notification.status === "draft" ? _c("span", {
-      staticClass: "label label-default"
-    }, [_vm._v("Draft")]) : [notification.status === "scheduled" ? _c("span", {
-      staticClass: "label label-info"
-    }, [_vm._v("Scheduled for " + _vm._s(_vm.getNotificationDate(notification)))]) : _c("span", {
-      staticClass: "label label-success"
-    }, [_vm._v("Sent on " + _vm._s(_vm.getNotificationDate(notification)))])]], 2)], 1), _vm._v(" "), _c("p", [notification.data.title ? _c("strong", [_vm._v(_vm._s(notification.data.title))]) : _vm._e(), _vm._v(" "), notification.data.title && notification.data.message ? _c("br") : _vm._e(), _vm._v("\n                    " + _vm._s(notification.data.message) + "\n                  ")]), _vm._v(" "), _c("Notification-Link", {
-      attrs: {
-        notification: notification
-      }
-    })], 1), _vm._v(" "), _c("td", {
-      staticClass: "list-col-notes"
-    }, [_c("Notification-Notes", {
-      attrs: {
-        notification: notification
-      },
-      on: {
-        "update:notification": function updateNotification($event) {
-          notification = $event;
-        }
-      }
-    })], 1), _vm._v(" "), _c("td", {
-      staticClass: "list-col-sent-to"
-    }, [_c("p", [_vm._v("\n                    " + _vm._s(_vm.userCount(notification))), _c("br"), _vm._v(" "), _c("small", [_vm._v("via "), notification.type === "in-app" ? [_vm._v("in-app")] : _vm._e(), _vm._v(" "), notification.type === "in-app" && notification.job ? [_vm._v("&")] : _vm._e(), _vm._v(" "), notification.job || notification.type === "push" ? [_vm._v("push")] : _vm._e(), _vm._v("\n                      notifications")], 2)])]), _vm._v(" "), _c("td", {
-      staticClass: "list-col-actions"
-    }, [_vm.notificationIsEditable(notification) ? _c("tooltip", {
-      attrs: {
-        title: "Edit"
-      }
-    }, [_c("a", {
-      attrs: {
-        href: "#"
-      },
-      on: {
-        click: function click($event) {
-          $event.preventDefault();
-          return _vm.editNotification(notification);
-        }
-      }
-    }, [_c("i", {
-      staticClass: "fa fa-fw fa-lg fa-pencil"
-    })])]) : _vm._e(), _vm._v(" "), _c("tooltip", {
-      attrs: {
-        title: "Copy"
-      }
-    }, [_c("a", {
-      attrs: {
-        href: "#"
-      },
-      on: {
-        click: function click($event) {
-          $event.preventDefault();
-          return _vm.cloneNotification(notification);
-        }
-      }
-    }, [_c("i", {
-      staticClass: "fa fa-fw fa-lg fa-copy"
-    })])]), _vm._v(" "), notification.pushResult ? _c("tooltip", {
-      attrs: {
-        title: "Push notification result"
-      }
-    }, [_c("popover", {
-      attrs: {
-        title: "Push notification result",
-        placement: "left",
-        content: _vm.getNotificationLog(notification),
-        "data-job-id": notification.job.id
-      }
-    }, [_c("a", {
-      attrs: {
-        href: "#"
-      },
-      on: {
-        click: function click($event) {
-          $event.preventDefault();
-          return _vm.doNothing.apply(null, arguments);
-        }
-      }
-    }, [_c("i", {
-      staticClass: "fa fa-fw fa-lg fa-list-alt"
-    })])])], 1) : _vm._e(), _vm._v(" "), _vm.notificationIsDeletable(notification) ? _c("tooltip", {
-      attrs: {
-        title: "Delete"
-      }
-    }, [_c("a", {
-      attrs: {
-        href: "#"
-      },
-      on: {
-        click: function click($event) {
-          $event.preventDefault();
-          return _vm.deleteNotification(notification);
-        }
-      }
-    }, [_c("i", {
-      staticClass: "fa fa-fw fa-lg fa-trash"
-    })])]) : _vm._e()], 1)]);
-  }), 0)]), _vm._v(" "), _c("div", {
-    staticClass: "list-pagination clearfix"
-  }, [_c("paginate", {
-    attrs: {
-      "page-count": _vm.pageCount,
-      "prev-text": "Prev",
-      "next-text": "Next",
-      "container-class": "pagination clearfix"
-    },
-    model: {
-      value: _vm.pageNumber,
-      callback: function callback($$v) {
-        _vm.pageNumber = $$v;
-      },
-      expression: "pageNumber"
-    }
-  }), _vm._v(" "), _c("span", {
-    staticClass: "top-align"
-  }, [_vm._v("Show rows:")]), _vm._v(" "), _c("label", {
-    staticClass: "select-proxy-display"
-  }, [_c("select", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.batchSize,
-      expression: "batchSize"
-    }],
-    staticClass: "hidden-select form-control",
-    on: {
-      change: function change($event) {
-        var $$selectedVal = Array.prototype.filter.call($event.target.options, function (o) {
-          return o.selected;
-        }).map(function (o) {
-          var val = "_value" in o ? o._value : o.value;
-          return val;
-        });
-        _vm.batchSize = $event.target.multiple ? $$selectedVal : $$selectedVal[0];
-      }
-    }
-  }, _vm._l(_vm.batchSizes, function (size, index) {
-    return _c("option", {
-      key: index,
-      domProps: {
-        value: size,
-        innerHTML: _vm._s(size)
-      }
-    });
-  }), 0), _vm._v(" "), _c("span", {
-    staticClass: "icon fa fa-chevron-down"
-  })])], 1)]]], 2)])]);
-};
-var staticRenderFns = [function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "col-xs-6"
-  }, [_c("p", [_c("a", {
-    staticClass: "btn btn-default show-settings pull-right",
-    attrs: {
-      href: "#"
-    }
-  }, [_c("i", {
-    staticClass: "fa fa-fw fa-lg fa-cog"
-  }), _vm._v(" Push notification settings")])])]);
-}, function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "notifications-empty"
-  }, [_c("h4", [_vm._v("Send a notification")]), _vm._v(" "), _c("p", [_vm._v("Communicate latest updates and promotions with your users so they can re-engage with your app.")])]);
-}, function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("label", {
-    attrs: {
-      "for": "show-timezone"
-    }
-  }, [_c("span", {
-    staticClass: "check"
-  }, [_c("i", {
-    staticClass: "fa fa-check"
-  })]), _vm._v(" Show timezones\n            ")]);
-}, function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("thead", [_c("tr", [_c("th", [_vm._v("Notification")]), _vm._v(" "), _c("th", [_vm._v("Notes")]), _vm._v(" "), _c("th", [_vm._v("Sent to")]), _vm._v(" "), _c("th")])]);
-}];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("div", { staticClass: "container-fluid" }, [
+    _c("div", { staticClass: "row" }, [
+      _c("div", { staticClass: "col-xs-6" }, [
+        _c("p", [
+          _c(
+            "a",
+            {
+              staticClass: "btn btn-primary",
+              attrs: { href: "#" },
+              on: {
+                click: function ($event) {
+                  $event.preventDefault()
+                  return _vm.createNotification.apply(null, arguments)
+                },
+              },
+            },
+            [
+              _c("i", { staticClass: "fa fa-fw fa-lg fa-plus" }),
+              _vm._v(" Create new"),
+            ]
+          ),
+        ]),
+      ]),
+      _vm._v(" "),
+      _vm._m(0),
+    ]),
+    _vm._v(" "),
+    _c("div", { staticClass: "row" }, [
+      _c(
+        "div",
+        { staticClass: "col-xs-12" },
+        [
+          _vm.isLoading
+            ? _c(
+                "div",
+                {
+                  staticClass: "notifications-loading spinner-holder animated",
+                },
+                [
+                  _c("div", { staticClass: "spinner-overlay" }),
+                  _vm._v(" "),
+                  _c("p", [_vm._v("Loading notifications")]),
+                ]
+              )
+            : [
+                !_vm.notifications.length
+                  ? [_vm._m(1)]
+                  : [
+                      _c("div", { staticClass: "checkbox checkbox-icon" }, [
+                        _c("input", {
+                          directives: [
+                            {
+                              name: "model",
+                              rawName: "v-model",
+                              value: _vm.showTimezone,
+                              expression: "showTimezone",
+                            },
+                          ],
+                          attrs: { id: "show-timezone", type: "checkbox" },
+                          domProps: {
+                            checked: Array.isArray(_vm.showTimezone)
+                              ? _vm._i(_vm.showTimezone, null) > -1
+                              : _vm.showTimezone,
+                          },
+                          on: {
+                            change: function ($event) {
+                              var $$a = _vm.showTimezone,
+                                $$el = $event.target,
+                                $$c = $$el.checked ? true : false
+                              if (Array.isArray($$a)) {
+                                var $$v = null,
+                                  $$i = _vm._i($$a, $$v)
+                                if ($$el.checked) {
+                                  $$i < 0 &&
+                                    (_vm.showTimezone = $$a.concat([$$v]))
+                                } else {
+                                  $$i > -1 &&
+                                    (_vm.showTimezone = $$a
+                                      .slice(0, $$i)
+                                      .concat($$a.slice($$i + 1)))
+                                }
+                              } else {
+                                _vm.showTimezone = $$c
+                              }
+                            },
+                          },
+                        }),
+                        _vm._v(" "),
+                        _vm._m(2),
+                      ]),
+                      _vm._v(" "),
+                      _c(
+                        "table",
+                        {
+                          staticClass:
+                            "table table-condensed notification-list",
+                        },
+                        [
+                          _vm._m(3),
+                          _vm._v(" "),
+                          _c(
+                            "tbody",
+                            _vm._l(_vm.notifications, function (notification) {
+                              return _c(
+                                "tr",
+                                {
+                                  key: _vm.getNotificationKey(notification),
+                                  attrs: {
+                                    "data-notification-id": notification.id,
+                                    "data-job-id":
+                                      notification.job && notification.job.id,
+                                  },
+                                },
+                                [
+                                  _c(
+                                    "td",
+                                    { staticClass: "list-col-content" },
+                                    [
+                                      _c(
+                                        "p",
+                                        [
+                                          _c(
+                                            "tooltip",
+                                            {
+                                              attrs: {
+                                                title:
+                                                  _vm.getNotificationTooltip(
+                                                    notification
+                                                  ),
+                                              },
+                                            },
+                                            [
+                                              notification.status === "draft"
+                                                ? _c(
+                                                    "span",
+                                                    {
+                                                      staticClass:
+                                                        "label label-default",
+                                                    },
+                                                    [_vm._v("Draft")]
+                                                  )
+                                                : [
+                                                    notification.status ===
+                                                    "scheduled"
+                                                      ? _c(
+                                                          "span",
+                                                          {
+                                                            staticClass:
+                                                              "label label-info",
+                                                          },
+                                                          [
+                                                            _vm._v(
+                                                              "Scheduled for " +
+                                                                _vm._s(
+                                                                  _vm.getNotificationDate(
+                                                                    notification
+                                                                  )
+                                                                )
+                                                            ),
+                                                          ]
+                                                        )
+                                                      : _c(
+                                                          "span",
+                                                          {
+                                                            staticClass:
+                                                              "label label-success",
+                                                          },
+                                                          [
+                                                            _vm._v(
+                                                              "Sent on " +
+                                                                _vm._s(
+                                                                  _vm.getNotificationDate(
+                                                                    notification
+                                                                  )
+                                                                )
+                                                            ),
+                                                          ]
+                                                        ),
+                                                  ],
+                                            ],
+                                            2
+                                          ),
+                                        ],
+                                        1
+                                      ),
+                                      _vm._v(" "),
+                                      _c("p", [
+                                        notification.data.title
+                                          ? _c("strong", [
+                                              _vm._v(
+                                                _vm._s(notification.data.title)
+                                              ),
+                                            ])
+                                          : _vm._e(),
+                                        _vm._v(" "),
+                                        notification.data.title &&
+                                        notification.data.message
+                                          ? _c("br")
+                                          : _vm._e(),
+                                        _vm._v(
+                                          "\n                    " +
+                                            _vm._s(notification.data.message) +
+                                            "\n                  "
+                                        ),
+                                      ]),
+                                      _vm._v(" "),
+                                      _c("Notification-Link", {
+                                        attrs: { notification: notification },
+                                      }),
+                                    ],
+                                    1
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "td",
+                                    { staticClass: "list-col-notes" },
+                                    [
+                                      _c("Notification-Notes", {
+                                        attrs: { notification: notification },
+                                        on: {
+                                          "update:notification": function (
+                                            $event
+                                          ) {
+                                            notification = $event
+                                          },
+                                        },
+                                      }),
+                                    ],
+                                    1
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "td",
+                                    { staticClass: "list-col-sent-to" },
+                                    [
+                                      _c("p", [
+                                        _vm._v(
+                                          "\n                    " +
+                                            _vm._s(_vm.userCount(notification))
+                                        ),
+                                        _c("br"),
+                                        _vm._v(" "),
+                                        _c(
+                                          "small",
+                                          [
+                                            _vm._v("via "),
+                                            notification.type === "in-app"
+                                              ? [_vm._v("in-app")]
+                                              : _vm._e(),
+                                            _vm._v(" "),
+                                            notification.type === "in-app" &&
+                                            notification.job
+                                              ? [_vm._v("&")]
+                                              : _vm._e(),
+                                            _vm._v(" "),
+                                            notification.job ||
+                                            notification.type === "push"
+                                              ? [_vm._v("push")]
+                                              : _vm._e(),
+                                            _vm._v(
+                                              "\n                      notifications"
+                                            ),
+                                          ],
+                                          2
+                                        ),
+                                      ]),
+                                    ]
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "td",
+                                    { staticClass: "list-col-actions" },
+                                    [
+                                      _vm.notificationIsEditable(notification)
+                                        ? _c(
+                                            "tooltip",
+                                            { attrs: { title: "Edit" } },
+                                            [
+                                              _c(
+                                                "a",
+                                                {
+                                                  attrs: { href: "#" },
+                                                  on: {
+                                                    click: function ($event) {
+                                                      $event.preventDefault()
+                                                      return _vm.editNotification(
+                                                        notification
+                                                      )
+                                                    },
+                                                  },
+                                                },
+                                                [
+                                                  _c("i", {
+                                                    staticClass:
+                                                      "fa fa-fw fa-lg fa-pencil",
+                                                  }),
+                                                ]
+                                              ),
+                                            ]
+                                          )
+                                        : _vm._e(),
+                                      _vm._v(" "),
+                                      _c(
+                                        "tooltip",
+                                        { attrs: { title: "Copy" } },
+                                        [
+                                          _c(
+                                            "a",
+                                            {
+                                              attrs: { href: "#" },
+                                              on: {
+                                                click: function ($event) {
+                                                  $event.preventDefault()
+                                                  return _vm.cloneNotification(
+                                                    notification
+                                                  )
+                                                },
+                                              },
+                                            },
+                                            [
+                                              _c("i", {
+                                                staticClass:
+                                                  "fa fa-fw fa-lg fa-copy",
+                                              }),
+                                            ]
+                                          ),
+                                        ]
+                                      ),
+                                      _vm._v(" "),
+                                      notification.pushResult
+                                        ? _c(
+                                            "tooltip",
+                                            {
+                                              attrs: {
+                                                title:
+                                                  "Push notification result",
+                                              },
+                                            },
+                                            [
+                                              _c(
+                                                "popover",
+                                                {
+                                                  attrs: {
+                                                    title:
+                                                      "Push notification result",
+                                                    placement: "left",
+                                                    content:
+                                                      _vm.getNotificationLog(
+                                                        notification
+                                                      ),
+                                                    "data-job-id":
+                                                      notification.job.id,
+                                                  },
+                                                },
+                                                [
+                                                  _c(
+                                                    "a",
+                                                    {
+                                                      attrs: { href: "#" },
+                                                      on: {
+                                                        click: function (
+                                                          $event
+                                                        ) {
+                                                          $event.preventDefault()
+                                                          return _vm.doNothing.apply(
+                                                            null,
+                                                            arguments
+                                                          )
+                                                        },
+                                                      },
+                                                    },
+                                                    [
+                                                      _c("i", {
+                                                        staticClass:
+                                                          "fa fa-fw fa-lg fa-list-alt",
+                                                      }),
+                                                    ]
+                                                  ),
+                                                ]
+                                              ),
+                                            ],
+                                            1
+                                          )
+                                        : _vm._e(),
+                                      _vm._v(" "),
+                                      _vm.notificationIsDeletable(notification)
+                                        ? _c(
+                                            "tooltip",
+                                            { attrs: { title: "Delete" } },
+                                            [
+                                              _c(
+                                                "a",
+                                                {
+                                                  attrs: { href: "#" },
+                                                  on: {
+                                                    click: function ($event) {
+                                                      $event.preventDefault()
+                                                      return _vm.deleteNotification(
+                                                        notification
+                                                      )
+                                                    },
+                                                  },
+                                                },
+                                                [
+                                                  _c("i", {
+                                                    staticClass:
+                                                      "fa fa-fw fa-lg fa-trash",
+                                                  }),
+                                                ]
+                                              ),
+                                            ]
+                                          )
+                                        : _vm._e(),
+                                    ],
+                                    1
+                                  ),
+                                ]
+                              )
+                            }),
+                            0
+                          ),
+                        ]
+                      ),
+                      _vm._v(" "),
+                      _c(
+                        "div",
+                        { staticClass: "list-pagination clearfix" },
+                        [
+                          _c("paginate", {
+                            attrs: {
+                              "page-count": _vm.pageCount,
+                              "prev-text": "Prev",
+                              "next-text": "Next",
+                              "container-class": "pagination clearfix",
+                            },
+                            model: {
+                              value: _vm.pageNumber,
+                              callback: function ($$v) {
+                                _vm.pageNumber = $$v
+                              },
+                              expression: "pageNumber",
+                            },
+                          }),
+                          _vm._v(" "),
+                          _c("span", { staticClass: "top-align" }, [
+                            _vm._v("Show rows:"),
+                          ]),
+                          _vm._v(" "),
+                          _c("label", { staticClass: "select-proxy-display" }, [
+                            _c(
+                              "select",
+                              {
+                                directives: [
+                                  {
+                                    name: "model",
+                                    rawName: "v-model",
+                                    value: _vm.batchSize,
+                                    expression: "batchSize",
+                                  },
+                                ],
+                                staticClass: "hidden-select form-control",
+                                on: {
+                                  change: function ($event) {
+                                    var $$selectedVal = Array.prototype.filter
+                                      .call(
+                                        $event.target.options,
+                                        function (o) {
+                                          return o.selected
+                                        }
+                                      )
+                                      .map(function (o) {
+                                        var val =
+                                          "_value" in o ? o._value : o.value
+                                        return val
+                                      })
+                                    _vm.batchSize = $event.target.multiple
+                                      ? $$selectedVal
+                                      : $$selectedVal[0]
+                                  },
+                                },
+                              },
+                              _vm._l(_vm.batchSizes, function (size, index) {
+                                return _c("option", {
+                                  key: index,
+                                  domProps: {
+                                    value: size,
+                                    innerHTML: _vm._s(size),
+                                  },
+                                })
+                              }),
+                              0
+                            ),
+                            _vm._v(" "),
+                            _c("span", {
+                              staticClass: "icon fa fa-chevron-down",
+                            }),
+                          ]),
+                        ],
+                        1
+                      ),
+                    ],
+              ],
+        ],
+        2
+      ),
+    ]),
+  ])
+}
+var staticRenderFns = [
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("div", { staticClass: "col-xs-6" }, [
+      _c("p", [
+        _c(
+          "a",
+          {
+            staticClass: "btn btn-default show-settings pull-right",
+            attrs: { href: "#" },
+          },
+          [
+            _c("i", { staticClass: "fa fa-fw fa-lg fa-cog" }),
+            _vm._v(" Push notification settings"),
+          ]
+        ),
+      ]),
+    ])
+  },
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("div", { staticClass: "notifications-empty" }, [
+      _c("h4", [_vm._v("Send a notification")]),
+      _vm._v(" "),
+      _c("p", [
+        _vm._v(
+          "Communicate latest updates and promotions with your users so they can re-engage with your project."
+        ),
+      ]),
+    ])
+  },
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("label", { attrs: { for: "show-timezone" } }, [
+      _c("span", { staticClass: "check" }, [
+        _c("i", { staticClass: "fa fa-check" }),
+      ]),
+      _vm._v(" Show timezones\n            "),
+    ])
+  },
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("thead", [
+      _c("tr", [
+        _c("th", [_vm._v("Notification")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("Notes")]),
+        _vm._v(" "),
+        _c("th", [_vm._v("Sent to")]),
+        _vm._v(" "),
+        _c("th"),
+      ]),
+    ])
+  },
+]
+render._withStripped = true
+
 
 
 /***/ }),
@@ -576,6 +908,119 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _libs_bus__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(25);
 /* harmony import */ var _libs_date__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(37);
 /* harmony import */ var _libs_timezones__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(38);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
 
 
 
@@ -886,10 +1331,10 @@ component.options.__file = "src/components/NotificationLink.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationLink_vue_vue_type_template_id_a5fc0596__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(13);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationLink_vue_vue_type_template_id_a5fc0596__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationLink_vue_vue_type_template_id_a5fc0596__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(13);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationLink_vue_vue_type_template_id_a5fc0596__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationLink_vue_vue_type_template_id_a5fc0596__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationLink_vue_vue_type_template_id_a5fc0596__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -901,29 +1346,57 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _vm.link.action ? _c("p", [_vm.link.action === "screen" ? [_vm._v("\n    Screen link: "), _c("a", {
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.previewPage.apply(null, arguments);
-      }
-    }
-  }, [_vm._v(_vm._s(_vm.pageName))])] : _vm._e(), _vm._v(" "), _vm.link.action === "url" ? [_vm._v("\n    URL link: "), _c("a", {
-    attrs: {
-      href: _vm.link.url,
-      target: "_blank",
-      title: _vm.link.url
-    }
-  }, [_vm._v(_vm._s(_vm.linkHost))])] : _vm._e()], 2) : _vm._e();
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _vm.link.action
+    ? _c(
+        "p",
+        [
+          _vm.link.action === "screen"
+            ? [
+                _vm._v("\n    Screen link: "),
+                _c(
+                  "a",
+                  {
+                    attrs: { href: "#" },
+                    on: {
+                      click: function ($event) {
+                        $event.preventDefault()
+                        return _vm.previewPage.apply(null, arguments)
+                      },
+                    },
+                  },
+                  [_vm._v(_vm._s(_vm.pageName))]
+                ),
+              ]
+            : _vm._e(),
+          _vm._v(" "),
+          _vm.link.action === "url"
+            ? [
+                _vm._v("\n    URL link: "),
+                _c(
+                  "a",
+                  {
+                    attrs: {
+                      href: _vm.link.url,
+                      target: "_blank",
+                      title: _vm.link.url,
+                    },
+                  },
+                  [_vm._v(_vm._s(_vm.linkHost))]
+                ),
+              ]
+            : _vm._e(),
+        ],
+        2
+      )
+    : _vm._e()
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -942,6 +1415,18 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _store__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(16);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   data: function data() {
@@ -1436,10 +1921,10 @@ component.options.__file = "src/components/NotificationNotes.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationNotes_vue_vue_type_template_id_7c3cf4d4__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(21);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationNotes_vue_vue_type_template_id_7c3cf4d4__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationNotes_vue_vue_type_template_id_7c3cf4d4__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(21);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationNotes_vue_vue_type_template_id_7c3cf4d4__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationNotes_vue_vue_type_template_id_7c3cf4d4__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationNotes_vue_vue_type_template_id_7c3cf4d4__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -1451,73 +1936,128 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", [!_vm.notification.id ? _c("p", {
-    staticClass: "notes-unsupported"
-  }, [_vm._v("Not supported")]) : [_vm.mode === "view" ? [_vm.notes ? [_c("p", {
-    staticClass: "notes-content",
-    domProps: {
-      innerHTML: _vm._s(_vm.getNotes())
-    }
-  }), _vm._v(" "), _c("p", {
-    staticClass: "notes-toolbar"
-  }, [_c("button", {
-    staticClass: "btn btn-sm btn-default",
-    on: {
-      click: function click($event) {
-        return _vm.edit();
-      }
-    }
-  }, [_vm._v("Edit notes")])])] : [_c("p", {
-    staticClass: "notes-toolbar"
-  }, [_c("button", {
-    staticClass: "btn btn-sm btn-default",
-    on: {
-      click: function click($event) {
-        return _vm.edit();
-      }
-    }
-  }, [_vm._v("Add notes")])])]] : _vm._e(), _vm._v(" "), _vm.mode === "edit" ? [_c("p", [_c("textarea", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.notes,
-      expression: "notes"
-    }],
-    staticClass: "form-control",
-    attrs: {
-      rows: "4",
-      placeholder: "(Optional) Add some notes to this notification. Your users will not see this."
-    },
-    domProps: {
-      value: _vm.notes
-    },
-    on: {
-      input: function input($event) {
-        if ($event.target.composing) return;
-        _vm.notes = $event.target.value;
-      }
-    }
-  })]), _vm._v(" "), _c("p", [_c("button", {
-    staticClass: "btn btn-sm btn-primary",
-    on: {
-      click: function click($event) {
-        return _vm.update();
-      }
-    }
-  }, [_vm._v("Save")]), _vm._v(" "), _c("button", {
-    staticClass: "btn btn-sm btn-default",
-    on: {
-      click: function click($event) {
-        return _vm.cancel();
-      }
-    }
-  }, [_vm._v("Cancel")])])] : _vm._e()]], 2);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "div",
+    [
+      !_vm.notification.id
+        ? _c("p", { staticClass: "notes-unsupported" }, [
+            _vm._v("Not supported"),
+          ])
+        : [
+            _vm.mode === "view"
+              ? [
+                  _vm.notes
+                    ? [
+                        _c("p", {
+                          staticClass: "notes-content",
+                          domProps: { innerHTML: _vm._s(_vm.getNotes()) },
+                        }),
+                        _vm._v(" "),
+                        _c("p", { staticClass: "notes-toolbar" }, [
+                          _c(
+                            "button",
+                            {
+                              staticClass: "btn btn-sm btn-default",
+                              on: {
+                                click: function ($event) {
+                                  return _vm.edit()
+                                },
+                              },
+                            },
+                            [_vm._v("Edit notes")]
+                          ),
+                        ]),
+                      ]
+                    : [
+                        _c("p", { staticClass: "notes-toolbar" }, [
+                          _c(
+                            "button",
+                            {
+                              staticClass: "btn btn-sm btn-default",
+                              on: {
+                                click: function ($event) {
+                                  return _vm.edit()
+                                },
+                              },
+                            },
+                            [_vm._v("Add notes")]
+                          ),
+                        ]),
+                      ],
+                ]
+              : _vm._e(),
+            _vm._v(" "),
+            _vm.mode === "edit"
+              ? [
+                  _c("p", [
+                    _c("textarea", {
+                      directives: [
+                        {
+                          name: "model",
+                          rawName: "v-model",
+                          value: _vm.notes,
+                          expression: "notes",
+                        },
+                      ],
+                      staticClass: "form-control",
+                      attrs: {
+                        rows: "4",
+                        placeholder:
+                          "(Optional) Add some notes to this notification. Your users will not see this.",
+                      },
+                      domProps: { value: _vm.notes },
+                      on: {
+                        input: function ($event) {
+                          if ($event.target.composing) {
+                            return
+                          }
+                          _vm.notes = $event.target.value
+                        },
+                      },
+                    }),
+                  ]),
+                  _vm._v(" "),
+                  _c("p", [
+                    _c(
+                      "button",
+                      {
+                        staticClass: "btn btn-sm btn-primary",
+                        on: {
+                          click: function ($event) {
+                            return _vm.update()
+                          },
+                        },
+                      },
+                      [_vm._v("Save")]
+                    ),
+                    _vm._v(" "),
+                    _c(
+                      "button",
+                      {
+                        staticClass: "btn btn-sm btn-default",
+                        on: {
+                          click: function ($event) {
+                            return _vm.cancel()
+                          },
+                        },
+                      },
+                      [_vm._v("Cancel")]
+                    ),
+                  ]),
+                ]
+              : _vm._e(),
+          ],
+    ],
+    2
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -1537,6 +2077,31 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _libs_string__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(24);
 /* harmony import */ var _libs_bus__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(25);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
@@ -1654,10 +2219,10 @@ component.options.__file = "src/components/Tooltip.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Tooltip_vue_vue_type_template_id_70596efa__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(28);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Tooltip_vue_vue_type_template_id_70596efa__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Tooltip_vue_vue_type_template_id_70596efa__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(28);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Tooltip_vue_vue_type_template_id_70596efa__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Tooltip_vue_vue_type_template_id_70596efa__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Tooltip_vue_vue_type_template_id_70596efa__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -1669,19 +2234,26 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("span", {
-    attrs: {
-      "data-toggle": "tooltip",
-      "data-placement": _vm.placement,
-      title: _vm.title
-    }
-  }, [_vm._t("default")], 2);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "span",
+    {
+      attrs: {
+        "data-toggle": "tooltip",
+        "data-placement": _vm.placement,
+        title: _vm.title,
+      },
+    },
+    [_vm._t("default")],
+    2
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -1699,6 +2271,13 @@ __webpack_require__.r(__webpack_exports__);
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+//
+//
+//
+//
+//
+//
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
     placement: {
@@ -1758,10 +2337,10 @@ component.options.__file = "src/components/Popover.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Popover_vue_vue_type_template_id_b98493b6__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(33);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Popover_vue_vue_type_template_id_b98493b6__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Popover_vue_vue_type_template_id_b98493b6__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(33);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Popover_vue_vue_type_template_id_b98493b6__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Popover_vue_vue_type_template_id_b98493b6__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Popover_vue_vue_type_template_id_b98493b6__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -1773,21 +2352,28 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("span", {
-    attrs: {
-      "data-toggle": "popover",
-      "data-placement": _vm.placement,
-      title: _vm.title,
-      "data-content": _vm.content,
-      "data-trigger": _vm.trigger
-    }
-  }, [_vm._t("default")], 2);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "span",
+    {
+      attrs: {
+        "data-toggle": "popover",
+        "data-placement": _vm.placement,
+        title: _vm.title,
+        "data-content": _vm.content,
+        "data-trigger": _vm.trigger,
+      },
+    },
+    [_vm._t("default")],
+    2
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -1805,6 +2391,13 @@ __webpack_require__.r(__webpack_exports__);
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+//
+//
+//
+//
+//
+//
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
     placement: {
@@ -2282,10 +2875,10 @@ component.options.__file = "src/components/NotificationForm.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationForm_vue_vue_type_template_id_fbe03602__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(41);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationForm_vue_vue_type_template_id_fbe03602__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationForm_vue_vue_type_template_id_fbe03602__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(41);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationForm_vue_vue_type_template_id_fbe03602__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationForm_vue_vue_type_template_id_fbe03602__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_NotificationForm_vue_vue_type_template_id_fbe03602__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -2297,800 +2890,1517 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", [_c("div", {
-    staticClass: "notification-form"
-  }, [_vm.isSaving ? _c("div", {
-    staticClass: "container-fluid"
-  }, [_c("div", {
-    staticClass: "spinner-holder animated"
-  }, [_c("div", {
-    staticClass: "spinner-overlay"
-  }), _vm._v(" "), _c("p", {
-    domProps: {
-      innerHTML: _vm._s(_vm.saveMessage)
-    }
-  })])]) : _c("div", {
-    staticClass: "container-fluid"
-  }, [_c("div", {
-    staticClass: "steps-holder"
-  }, _vm._l(_vm.steps, function (stepObj, index) {
-    return _c("div", {
-      key: stepObj.name,
-      staticClass: "step",
-      "class": {
-        active: index === _vm.step
-      }
-    });
-  }), 0), _vm._v(" "), _c("div", {
-    directives: [{
-      name: "show",
-      rawName: "v-show",
-      value: _vm.steps[_vm.step].name === "configure",
-      expression: "steps[step].name === 'configure'"
-    }],
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-md-8 col-md-offset-2"
-  }, [_c("h3", [_vm._v("Configure your notification")]), _vm._v(" "), _c("div", {
-    staticClass: "form-group clearfix"
-  }, [_c("input", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.notification.data.title,
-      expression: "notification.data.title"
-    }],
-    staticClass: "form-control",
-    attrs: {
-      type: "text",
-      placeholder: "Enter notification title",
-      "data-count-selector": "#title-count",
-      maxlength: _vm.titleCharacterLimit,
-      required: ""
-    },
-    domProps: {
-      value: _vm.notification.data.title
-    },
-    on: {
-      input: function input($event) {
-        if ($event.target.composing) return;
-        _vm.$set(_vm.notification.data, "title", $event.target.value);
-      }
-    }
-  }), _vm._v(" "), _c("div", {
-    staticClass: "pull-right",
-    "class": {
-      "text-success": _vm.titleCharactersRemaining >= 0,
-      "text-danger": _vm.titleCharactersRemaining < 0
-    }
-  }, [_vm._v(_vm._s(_vm.titleCharactersRemaining) + " character"), _vm.titleCharactersRemaining !== 1 ? void 0 : _vm._e(), _vm._v(" left")], 2), _vm._v(" "), _vm.errors.title ? _c("div", {
-    staticClass: "text-danger"
-  }, [_vm._v(_vm._s(_vm.errors.title))]) : _vm._e()]), _vm._v(" "), _c("div", {
-    staticClass: "form-group clearfix"
-  }, [_c("textarea", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.notification.data.message,
-      expression: "notification.data.message"
-    }],
-    staticClass: "form-control",
-    attrs: {
-      rows: "4",
-      placeholder: "Enter notification message (15 words recommended)",
-      maxlength: _vm.messageCharacterLimit,
-      required: ""
-    },
-    domProps: {
-      value: _vm.notification.data.message
-    },
-    on: {
-      input: function input($event) {
-        if ($event.target.composing) return;
-        _vm.$set(_vm.notification.data, "message", $event.target.value);
-      }
-    }
-  }), _vm._v(" "), _c("div", {
-    staticClass: "pull-right",
-    "class": {
-      "text-success": _vm.messageCharactersRemaining >= 0,
-      "text-danger": _vm.messageCharactersRemaining < 0
-    }
-  }, [_vm._v(_vm._s(_vm.messageCharactersRemaining) + " character"), _vm.messageCharactersRemaining !== 1 ? void 0 : _vm._e(), _vm._v(" left")], 2), _vm._v(" "), _vm.errors.message ? _c("div", {
-    staticClass: "text-danger"
-  }, [_vm._v(_vm._s(_vm.errors.message))]) : _vm._e()]), _vm._v(" "), _c("div", {
-    staticClass: "form-group clearfix"
-  }, [_c("h3", [_vm._v("Add a link")]), _vm._v(" "), _c("div", {
-    staticClass: "tab-selection"
-  }, [_c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.linkAction === ""
-    },
-    on: {
-      click: function click($event) {
-        _vm.linkAction = "";
-      }
-    }
-  }, [_vm._v("No link")]), _vm._v(" "), _c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.linkAction === "screen"
-    },
-    on: {
-      click: function click($event) {
-        _vm.linkAction = "screen";
-      }
-    }
-  }, [_vm._v("Link to screen")]), _vm._v(" "), _c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.linkAction === "url"
-    },
-    on: {
-      click: function click($event) {
-        _vm.linkAction = "url";
-      }
-    }
-  }, [_vm._v("Link to web page")])])]), _vm._v(" "), _c("div", {
-    directives: [{
-      name: "show",
-      rawName: "v-show",
-      value: _vm.linkAction !== "none",
-      expression: "linkAction !== 'none'"
-    }],
-    staticClass: "clearfix link-providers"
-  }, [_c("div", {
-    directives: [{
-      name: "show",
-      rawName: "v-show",
-      value: _vm.linkAction === "screen",
-      expression: "linkAction === 'screen'"
-    }],
-    staticClass: "form-group"
-  }, [_c("div", {
-    ref: "screenLinkProvider"
-  }), _vm._v(" "), _vm.errors.screenLink ? _c("div", {
-    staticClass: "text-danger"
-  }, [_vm._v(_vm._s(_vm.errors.screenLink))]) : _vm._e(), _vm._v(" "), _c("p", {
-    staticClass: "text-center"
-  }, [_c("a", {
-    staticClass: "btn btn-default",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.previewScreenLink.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Preview target screen")])])]), _vm._v(" "), _c("div", {
-    directives: [{
-      name: "show",
-      rawName: "v-show",
-      value: _vm.linkAction === "url",
-      expression: "linkAction === 'url'"
-    }],
-    staticClass: "form-group"
-  }, [_c("div", {
-    ref: "urlLinkProvider"
-  }), _vm._v(" "), _vm.errors.urlLink ? _c("div", {
-    staticClass: "text-danger"
-  }, [_vm._v(_vm._s(_vm.errors.urlLink))]) : _vm._e()])]), _vm._v(" "), _c("p", {
-    staticClass: "step-summary"
-  }, [_c("a", {
-    staticClass: "btn btn-default",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.cancel.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Cancel")]), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-primary",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.nextStep.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Select recipients")]), _c("br"), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-link",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.save("draft");
-      }
-    }
-  }, [_vm._v("Save as draft")])])])]), _vm._v(" "), _vm.steps[_vm.step].name === "recipients" ? _c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-md-10 col-md-offset-1"
-  }, [_c("h3", [_vm._v("Send notification to...")]), _vm._v(" "), _c("div", {
-    staticClass: "tab-selection"
-  }, [_c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.audience === ""
-    },
-    on: {
-      click: function click($event) {
-        _vm.audience = "";
-      }
-    }
-  }, [_vm._v("All users")]), _vm._v(" "), _c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.audience === "loggedIn"
-    },
-    on: {
-      click: function click($event) {
-        _vm.audience = "loggedIn";
-      }
-    }
-  }, [_vm._v("Signed in users")]), _vm._v(" "), _c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.audience === "sessions"
-    },
-    on: {
-      click: function click($event) {
-        _vm.audience = "sessions";
-      }
-    }
-  }, [_vm._v("Test sessions")])]), _vm._v(" "), _vm.audience !== "sessions" && _vm.filters.length ? [_c("h4", [_vm._v("Recipients must match all of the following")]), _vm._v(" "), _vm._l(_vm.filters, function (filter, index) {
-    return _c("div", {
-      key: index,
-      staticClass: "filters"
-    }, [_c("div", {
-      staticClass: "form-group clearfix"
-    }, [_c("div", {
-      staticClass: "col-xs-1"
-    }, [_c("span", {
-      staticClass: "btn btn-circle btn-default",
-      on: {
-        click: function click($event) {
-          return _vm.removeFilter(index);
-        }
-      }
-    }, [_c("i", {
-      staticClass: "fa fa-fw fa-minus"
-    })])]), _vm._v(" "), _c("div", {
-      staticClass: "col-xs-4"
-    }, [_c("p", [_c("input", {
-      directives: [{
-        name: "model",
-        rawName: "v-model",
-        value: filter.column,
-        expression: "filter.column"
-      }],
-      staticClass: "form-control",
-      attrs: {
-        type: "text",
-        placeholder: "Field name"
-      },
-      domProps: {
-        value: filter.column
-      },
-      on: {
-        input: function input($event) {
-          if ($event.target.composing) return;
-          _vm.$set(filter, "column", $event.target.value);
-        }
-      }
-    })]), _vm._v(" "), _c("div", {
-      staticClass: "form-inline filter-path"
-    }, [!_vm.showFilterPath(filter) ? _c("a", {
-      staticClass: "add-path",
-      attrs: {
-        href: "#",
-        tabindex: "-1"
-      },
-      on: {
-        click: function click($event) {
-          $event.preventDefault();
-          return _vm.addFilterPath(filter);
-        }
-      }
-    }, [_vm._v("This field is an object")]) : _c("div", {
-      staticClass: "form-group"
-    }, [_c("label", {
-      staticClass: "filter-path-label"
-    }, [_vm._v("Path")]), _vm._v(" "), _c("input", {
-      directives: [{
-        name: "model",
-        rawName: "v-model",
-        value: filter.path,
-        expression: "filter.path"
-      }],
-      staticClass: "form-control",
-      attrs: {
-        type: "text",
-        placeholder: "e.g. companies[0].name"
-      },
-      domProps: {
-        value: filter.path
-      },
-      on: {
-        input: function input($event) {
-          if ($event.target.composing) return;
-          _vm.$set(filter, "path", $event.target.value);
-        }
-      }
-    }), _vm._v(" "), _c("i", {
-      staticClass: "fa fa-fw fa-times",
-      on: {
-        click: function click($event) {
-          return _vm.removeFilterPath(filter);
-        }
-      }
-    })])])]), _vm._v(" "), _c("div", {
-      staticClass: "col-xs-3"
-    }, [_c("label", {
-      staticClass: "select-proxy-display"
-    }, [_c("select", {
-      directives: [{
-        name: "model",
-        rawName: "v-model",
-        value: filter.condition,
-        expression: "filter.condition"
-      }],
-      staticClass: "hidden-select form-control",
-      on: {
-        change: function change($event) {
-          var $$selectedVal = Array.prototype.filter.call($event.target.options, function (o) {
-            return o.selected;
-          }).map(function (o) {
-            var val = "_value" in o ? o._value : o.value;
-            return val;
-          });
-          _vm.$set(filter, "condition", $event.target.multiple ? $$selectedVal : $$selectedVal[0]);
-        }
-      }
-    }, _vm._l(_vm.filterTypes, function (type) {
-      return _c("option", {
-        key: type.name,
-        domProps: {
-          value: type.name,
-          innerHTML: _vm._s(type.label)
-        }
-      });
-    }), 0), _vm._v(" "), _c("span", {
-      staticClass: "icon fa fa-chevron-down"
-    })])]), _vm._v(" "), _c("div", {
-      staticClass: "col-xs-4"
-    }, [_c("Filter-Value", {
-      attrs: {
-        type: _vm.getFilterValueType(filter),
-        value: filter.value
-      },
-      on: {
-        "update:value": function updateValue($event) {
-          return _vm.$set(filter, "value", $event);
-        }
-      }
-    })], 1)])]);
-  })] : _vm._e(), _vm._v(" "), _vm.audience === "sessions" ? [_c("h4", [_vm._v("Session IDs")]), _vm._v(" "), _c("p", {
-    staticClass: "text-center"
-  }, [_vm._v("To test notifications with individual devices, enter the session ID for each device.")]), _vm._v(" "), _c("p", [_c("Token-Field", {
-    attrs: {
-      value: _vm.sessions,
-      placeholder: "Separate multiple IDs with commas"
-    },
-    on: {
-      "update:value": function updateValue($event) {
-        _vm.sessions = $event;
-      }
-    }
-  })], 1), _vm._v(" "), _vm._m(0), _vm._v(" "), _vm.errors.sessions ? _c("p", {
-    staticClass: "text-center text-danger"
-  }, [_vm._v(_vm._s(_vm.errors.sessions))]) : _vm._e()] : _vm._e(), _vm._v(" "), _c("div", {
-    staticClass: "col-xs-12 filter-summary"
-  }, [_c("div", {
-    staticClass: "col-xs-8"
-  }, [_vm.audience !== "sessions" ? _c("p", [_c("a", {
-    staticClass: "btn btn-default",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.addFilter.apply(null, arguments);
-      }
-    }
-  }, [_c("i", {
-    staticClass: "fa fa-fw fa-plus"
-  }), _vm._v(" Add filter")]), _vm._v(" "), _c("a", {
-    staticClass: "filter-help",
-    attrs: {
-      href: "https://help.fliplet.com/notifications-component/",
-      target: "_blank"
-    }
-  }, [_vm._v("How to add data for filtering users")])]) : _vm._e()]), _vm._v(" "), _c("div", {
-    staticClass: "col-xs-4 text-right"
-  }, [_c("p", [_vm.audience !== "" || _vm.filterScopes.length ? _c("span", {
-    staticClass: "recipient-count"
-  }, [_vm.loadingMatches ? [_vm._v("\n                    Estimating...\n                  ")] : [_vm._v("\n                    Estimated: " + _vm._s(_vm.matches.count) + " user"), _vm.matches.count !== 1 ? [_vm._v("s")] : _vm._e(), _vm._v(" "), _c("tooltip", {
-    attrs: {
-      title: "This is an approximation and will depend on the user preference at the time of publish. Users who have never used the app will be excluded."
-    }
-  }, [_c("i", {
-    staticClass: "fa fa-info-circle"
-  })])]], 2) : _vm._e()])])]), _vm._v(" "), _c("div", {
-    staticClass: "form-group"
-  }, [_c("h3", [_vm._v("Notes")]), _vm._v(" "), _c("textarea", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.notes,
-      expression: "notes"
-    }],
-    staticClass: "form-control",
-    attrs: {
-      rows: "4",
-      placeholder: "(Optional) Add some notes to this notification. Your users will not see this."
-    },
-    domProps: {
-      value: _vm.notes
-    },
-    on: {
-      input: function input($event) {
-        if ($event.target.composing) return;
-        _vm.notes = $event.target.value;
-      }
-    }
-  })]), _vm._v(" "), _c("p", {
-    staticClass: "step-summary"
-  }, [_c("a", {
-    staticClass: "btn btn-default",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.prevStep.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Back")]), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-primary",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.nextStep.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Prepare for send")]), _c("br"), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-link",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.save("draft");
-      }
-    }
-  }, [_vm._v("Save as draft")])])], 2)]) : _vm._e(), _vm._v(" "), _vm.steps[_vm.step].name === "schedule" ? [_vm._m(1), _vm._v(" "), _c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-md-8 col-md-offset-2"
-  }, [_c("div", {
-    staticClass: "tab-selection"
-  }, [_c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.schedule === "now"
-    },
-    on: {
-      click: function click($event) {
-        _vm.schedule = "now";
-      }
-    }
-  }, [_vm._v("Now")]), _vm._v(" "), _c("span", {
-    staticClass: "tab",
-    "class": {
-      active: _vm.schedule === "scheduled"
-    },
-    on: {
-      click: function click($event) {
-        _vm.schedule = "scheduled";
-      }
-    }
-  }, [_vm._v("Later")])])])]), _vm._v(" "), _vm.schedule === "scheduled" ? _c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-md-8 col-md-offset-2 text-center"
-  }, [_c("Datepicker", {
-    attrs: {
-      inline: true,
-      "monday-first": true,
-      required: true,
-      "disabled-dates": _vm.disabledDates
-    },
-    on: {
-      changedMonth: _vm.autosize,
-      changedYear: _vm.autosize,
-      changedDecade: _vm.autosize
-    },
-    model: {
-      value: _vm.scheduledAtDate,
-      callback: function callback($$v) {
-        _vm.scheduledAtDate = $$v;
-      },
-      expression: "scheduledAtDate"
-    }
-  }), _vm._v(" "), _c("Timepicker", {
-    attrs: {
-      hour: _vm.scheduledAtHour,
-      minute: _vm.scheduledAtMinute,
-      timezone: _vm.scheduledAtTimezone,
-      date: _vm.scheduledAtDate
-    },
-    on: {
-      "update:hour": function updateHour($event) {
-        _vm.scheduledAtHour = $event;
-      },
-      "update:minute": function updateMinute($event) {
-        _vm.scheduledAtMinute = $event;
-      },
-      "update:timezone": function updateTimezone($event) {
-        _vm.scheduledAtTimezone = $event;
-      },
-      "update:date": function updateDate($event) {
-        _vm.scheduledAtDate = $event;
-      }
-    }
-  })], 1)]) : _vm._e(), _vm._v(" "), _c("div", {
-    staticClass: "row"
-  }, [_c("h3", [_vm._v("Show notification as...")]), _vm._v(" "), _c("div", {
-    staticClass: "col-md-8 col-md-offset-2"
-  }, [_c("div", {
-    staticClass: "tab-selection"
-  }, [_c("span", {
-    staticClass: "tab tab-checked",
-    "class": {
-      active: _vm.notificationHasChannel("in-app")
-    },
-    on: {
-      click: function click($event) {
-        return _vm.toggleNotificationChannel("in-app");
-      }
-    }
-  }, [_vm._v("In-app notification")]), _vm._v(" "), _c("span", {
-    staticClass: "tab tab-checked",
-    "class": {
-      active: _vm.notificationHasChannel("push")
-    },
-    on: {
-      click: function click($event) {
-        return _vm.toggleNotificationChannel("push");
-      }
-    }
-  }, [_vm._v("Push notification")])]), _vm._v(" "), _vm._m(2), _vm._v(" "), !_vm.pushIsConfigured ? _c("div", {
-    staticClass: "alert alert-warning"
-  }, [_vm._v("To send push notifications to your native app, you must configure push notifications on "), _c("a", {
-    attrs: {
-      href: "https://help.fliplet.com/configure-push-notifications-for-ios/",
-      target: "_blank"
-    }
-  }, [_vm._v("iOS")]), _vm._v(" and "), _c("a", {
-    attrs: {
-      href: "https://help.fliplet.com/configure-push-notifications-for-android/",
-      target: "_blank"
-    }
-  }, [_vm._v("Android")]), _vm._v(".")]) : _vm._e(), _vm._v(" "), _vm.errors.channels ? _c("p", {
-    staticClass: "text-center text-danger"
-  }, [_vm._v(_vm._s(_vm.errors.channels))]) : _vm._e()])]), _vm._v(" "), _c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-md-8 col-md-offset-2"
-  }, [_c("p", {
-    staticClass: "step-summary"
-  }, [_c("a", {
-    staticClass: "btn btn-default",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.prevStep.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Back")]), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-primary",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.nextStep.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Review")]), _c("br"), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-link",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.save("draft");
-      }
-    }
-  }, [_vm._v("Save as draft")])])])])] : _vm._e(), _vm._v(" "), _c("div", {
-    directives: [{
-      name: "show",
-      rawName: "v-show",
-      value: _vm.steps[_vm.step].name === "review",
-      expression: "steps[step].name === 'review'"
-    }],
-    staticClass: "row notification-review"
-  }, [_c("div", {
-    staticClass: "col-md-10 col-md-offset-1"
-  }, [_c("h3", [_vm._v("Your notification")]), _vm._v(" "), _vm.notificationHasChannel("in-app") ? [_c("div", {
-    staticClass: "notification-message"
-  }, [_c("strong", [_vm._v(_vm._s(_vm.notification.data.title))]), _c("br"), _vm._v(_vm._s(_vm.notification.data.message) + "\n            ")])] : _vm._e(), _vm._v(" "), _vm.notificationHasChannel("push") ? _c("div", {
-    staticClass: "push-notification-preview"
-  }, [_vm.notificationHasChannel("in-app") ? _c("h4", [_vm._v("A push notification will also be sent")]) : _vm._e(), _vm._v(" "), _vm._m(3), _vm._v(" "), _c("div", {
-    staticClass: "visible-sm-block visible-md-block visible-lg-block",
-    attrs: {
-      id: "notification-message-preview"
-    }
-  }, [_c("img", {
-    attrs: {
-      src: _vm.getAsset("img/notifications_device_preview_empty.jpg")
-    }
-  }), _vm._v(" "), _c("div", {
-    attrs: {
-      id: "notification-preview-home"
-    }
-  }, [_c("img", {
-    staticClass: "app-icon-preview",
-    attrs: {
-      src: _vm.appIcon
-    }
-  }), _vm._v(" "), _c("strong", {
-    staticClass: "app-name"
-  }, [_vm._v(_vm._s(_vm.appName))]), _vm._v(" "), _c("span", {
-    staticClass: "notification-message"
-  }, [_c("strong", [_vm._v(_vm._s(_vm.notification.data.title))]), _c("br"), _vm._v(_vm._s(_vm.notification.data.message) + "\n                ")])]), _vm._v(" "), _c("div", {
-    attrs: {
-      id: "notification-preview-icon-home"
-    }
-  }, [_c("img", {
-    staticClass: "app-icon-preview",
-    attrs: {
-      src: _vm.appIcon
-    }
-  }), _vm._v(" "), _c("strong", {
-    staticClass: "app-name"
-  }, [_vm._v(_vm._s(_vm.appName))])]), _vm._v(" "), _c("div", {
-    attrs: {
-      id: "notification-preview-lockscreen"
-    }
-  }, [_c("img", {
-    staticClass: "app-icon-preview",
-    attrs: {
-      src: _vm.appIcon
-    }
-  }), _vm._v(" "), _c("strong", {
-    staticClass: "app-name"
-  }, [_vm._v(_vm._s(_vm.appName))]), _vm._v(" "), _c("span", {
-    staticClass: "notification-message"
-  }, [_c("strong", [_vm._v(_vm._s(_vm.notification.data.title))]), _c("br"), _vm._v(_vm._s(_vm.notification.data.message) + "\n                ")])]), _vm._v(" "), _c("div", {
-    attrs: {
-      id: "notification-preview-notification-center"
-    }
-  }, [_c("img", {
-    staticClass: "app-icon-preview",
-    attrs: {
-      src: _vm.appIcon
-    }
-  }), _vm._v(" "), _c("strong", {
-    staticClass: "app-name"
-  }), _vm._v(" "), _c("span", {
-    staticClass: "notification-message"
-  }, [_c("strong", [_vm._v(_vm._s(_vm.notification.data.title))]), _c("br"), _vm._v(_vm._s(_vm.notification.data.message) + "\n                ")])])])]) : _vm._e(), _vm._v(" "), _c("h4", [_vm._v("Sending to\n            "), _vm.audience === "" && !_vm.filterScopes.length ? [_vm._v("all users")] : [_c("strong", [_vm._v(_vm._s(_vm.matches.count))]), _vm._v(" " + _vm._s(_vm.audienceVerbose) + " user"), _vm.matches.count !== 1 ? [_vm._v("s")] : _vm._e()], _vm._v(" "), _vm.filterScopes.length ? [_vm._v("matching all of the following")] : _vm._e()], 2), _vm._v(" "), _vm.filterScopes.length ? [_c("ul", {
-    staticClass: "filter-summary-items"
-  }, _vm._l(_vm.filters, function (filter, index) {
-    return _c("li", {
-      key: index,
-      domProps: {
-        innerHTML: _vm._s(_vm.getFilterVerbose(filter))
-      }
-    });
-  }), 0)] : _vm._e(), _vm._v(" "), _c("h4", [_vm._v("Send the notification " + _vm._s(_vm.scheduleVerbose))]), _vm._v(" "), _vm.schedule === "scheduled" ? _c("p", {
-    domProps: {
-      innerHTML: _vm._s(_vm.notificationDate)
-    }
-  }) : _vm._e(), _vm._v(" "), _c("p", {
-    staticClass: "step-summary"
-  }, [_c("a", {
-    staticClass: "btn btn-default",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.prevStep.apply(null, arguments);
-      }
-    }
-  }, [_vm._v("Back")]), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-primary",
-    attrs: {
-      href: "#"
-    },
-    domProps: {
-      innerHTML: _vm._s(_vm.getSendLabel())
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.send();
-      }
-    }
-  }), _c("br"), _vm._v(" "), _c("a", {
-    staticClass: "btn btn-link",
-    attrs: {
-      href: "#"
-    },
-    on: {
-      click: function click($event) {
-        $event.preventDefault();
-        return _vm.save("draft");
-      }
-    }
-  }, [_vm._v("Save as draft")])])], 2)])], 2)])]);
-};
-var staticRenderFns = [function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("p", {
-    staticClass: "help-block text-center"
-  }, [_vm._v("You can find your session ID by going to "), _c("strong", [_vm._v("About this app")]), _vm._v(" in the app on your device.")]);
-}, function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "row"
-  }, [_c("div", {
-    staticClass: "col-md-10 col-md-offset-1"
-  }, [_c("h3", [_vm._v("Send notification...")])])]);
-}, function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "alert alert-info"
-  }, [_c("strong", [_vm._v("New!")]), _vm._v(" Web apps can now receive push notifications.")]);
-}, function () {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("p", [_c("small", {
-    staticClass: "text-info"
-  }, [_vm._v("Appearance of the notification is subject to users' device, preference and accepting to receive notifications.")])]);
-}];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("div", [
+    _c("div", { staticClass: "notification-form" }, [
+      _vm.isSaving
+        ? _c("div", { staticClass: "container-fluid" }, [
+            _c("div", { staticClass: "spinner-holder animated" }, [
+              _c("div", { staticClass: "spinner-overlay" }),
+              _vm._v(" "),
+              _c("p", { domProps: { innerHTML: _vm._s(_vm.saveMessage) } }),
+            ]),
+          ])
+        : _c(
+            "div",
+            { staticClass: "container-fluid" },
+            [
+              _c(
+                "div",
+                { staticClass: "steps-holder" },
+                _vm._l(_vm.steps, function (stepObj, index) {
+                  return _c("div", {
+                    key: stepObj.name,
+                    staticClass: "step",
+                    class: { active: index === _vm.step },
+                  })
+                }),
+                0
+              ),
+              _vm._v(" "),
+              _c(
+                "div",
+                {
+                  directives: [
+                    {
+                      name: "show",
+                      rawName: "v-show",
+                      value: _vm.steps[_vm.step].name === "configure",
+                      expression: "steps[step].name === 'configure'",
+                    },
+                  ],
+                  staticClass: "row",
+                },
+                [
+                  _c("div", { staticClass: "col-md-8 col-md-offset-2" }, [
+                    _c("h3", [_vm._v("Configure your notification")]),
+                    _vm._v(" "),
+                    _c("div", { staticClass: "form-group clearfix" }, [
+                      _c("input", {
+                        directives: [
+                          {
+                            name: "model",
+                            rawName: "v-model",
+                            value: _vm.notification.data.title,
+                            expression: "notification.data.title",
+                          },
+                        ],
+                        staticClass: "form-control",
+                        attrs: {
+                          type: "text",
+                          placeholder: "Enter notification title",
+                          "data-count-selector": "#title-count",
+                          maxlength: _vm.titleCharacterLimit,
+                          required: "",
+                        },
+                        domProps: { value: _vm.notification.data.title },
+                        on: {
+                          input: function ($event) {
+                            if ($event.target.composing) {
+                              return
+                            }
+                            _vm.$set(
+                              _vm.notification.data,
+                              "title",
+                              $event.target.value
+                            )
+                          },
+                        },
+                      }),
+                      _vm._v(" "),
+                      _c(
+                        "div",
+                        {
+                          staticClass: "pull-right",
+                          class: {
+                            "text-success": _vm.titleCharactersRemaining >= 0,
+                            "text-danger": _vm.titleCharactersRemaining < 0,
+                          },
+                        },
+                        [
+                          _vm._v(
+                            _vm._s(_vm.titleCharactersRemaining) + " character"
+                          ),
+                          _vm.titleCharactersRemaining !== 1
+                            ? void 0
+                            : _vm._e(),
+                          _vm._v(" left"),
+                        ],
+                        2
+                      ),
+                      _vm._v(" "),
+                      _vm.errors.title
+                        ? _c("div", { staticClass: "text-danger" }, [
+                            _vm._v(_vm._s(_vm.errors.title)),
+                          ])
+                        : _vm._e(),
+                    ]),
+                    _vm._v(" "),
+                    _c("div", { staticClass: "form-group clearfix" }, [
+                      _c("textarea", {
+                        directives: [
+                          {
+                            name: "model",
+                            rawName: "v-model",
+                            value: _vm.notification.data.message,
+                            expression: "notification.data.message",
+                          },
+                        ],
+                        staticClass: "form-control",
+                        attrs: {
+                          rows: "4",
+                          placeholder:
+                            "Enter notification message (15 words recommended)",
+                          maxlength: _vm.messageCharacterLimit,
+                          required: "",
+                        },
+                        domProps: { value: _vm.notification.data.message },
+                        on: {
+                          input: function ($event) {
+                            if ($event.target.composing) {
+                              return
+                            }
+                            _vm.$set(
+                              _vm.notification.data,
+                              "message",
+                              $event.target.value
+                            )
+                          },
+                        },
+                      }),
+                      _vm._v(" "),
+                      _c(
+                        "div",
+                        {
+                          staticClass: "pull-right",
+                          class: {
+                            "text-success": _vm.messageCharactersRemaining >= 0,
+                            "text-danger": _vm.messageCharactersRemaining < 0,
+                          },
+                        },
+                        [
+                          _vm._v(
+                            _vm._s(_vm.messageCharactersRemaining) +
+                              " character"
+                          ),
+                          _vm.messageCharactersRemaining !== 1
+                            ? void 0
+                            : _vm._e(),
+                          _vm._v(" left"),
+                        ],
+                        2
+                      ),
+                      _vm._v(" "),
+                      _vm.errors.message
+                        ? _c("div", { staticClass: "text-danger" }, [
+                            _vm._v(_vm._s(_vm.errors.message)),
+                          ])
+                        : _vm._e(),
+                    ]),
+                    _vm._v(" "),
+                    _c("div", { staticClass: "form-group clearfix" }, [
+                      _c("h3", [_vm._v("Add a link")]),
+                      _vm._v(" "),
+                      _c("div", { staticClass: "tab-selection" }, [
+                        _c(
+                          "span",
+                          {
+                            staticClass: "tab",
+                            class: { active: _vm.linkAction === "" },
+                            on: {
+                              click: function ($event) {
+                                _vm.linkAction = ""
+                              },
+                            },
+                          },
+                          [_vm._v("No link")]
+                        ),
+                        _vm._v(" "),
+                        _c(
+                          "span",
+                          {
+                            staticClass: "tab",
+                            class: { active: _vm.linkAction === "screen" },
+                            on: {
+                              click: function ($event) {
+                                _vm.linkAction = "screen"
+                              },
+                            },
+                          },
+                          [_vm._v("Link to screen")]
+                        ),
+                        _vm._v(" "),
+                        _c(
+                          "span",
+                          {
+                            staticClass: "tab",
+                            class: { active: _vm.linkAction === "url" },
+                            on: {
+                              click: function ($event) {
+                                _vm.linkAction = "url"
+                              },
+                            },
+                          },
+                          [_vm._v("Link to web page")]
+                        ),
+                      ]),
+                    ]),
+                    _vm._v(" "),
+                    _c(
+                      "div",
+                      {
+                        directives: [
+                          {
+                            name: "show",
+                            rawName: "v-show",
+                            value: _vm.linkAction !== "none",
+                            expression: "linkAction !== 'none'",
+                          },
+                        ],
+                        staticClass: "clearfix link-providers",
+                      },
+                      [
+                        _c(
+                          "div",
+                          {
+                            directives: [
+                              {
+                                name: "show",
+                                rawName: "v-show",
+                                value: _vm.linkAction === "screen",
+                                expression: "linkAction === 'screen'",
+                              },
+                            ],
+                            staticClass: "form-group",
+                          },
+                          [
+                            _c("div", { ref: "screenLinkProvider" }),
+                            _vm._v(" "),
+                            _vm.errors.screenLink
+                              ? _c("div", { staticClass: "text-danger" }, [
+                                  _vm._v(_vm._s(_vm.errors.screenLink)),
+                                ])
+                              : _vm._e(),
+                            _vm._v(" "),
+                            _c("p", { staticClass: "text-center" }, [
+                              _c(
+                                "a",
+                                {
+                                  staticClass: "btn btn-default",
+                                  attrs: { href: "#" },
+                                  on: {
+                                    click: function ($event) {
+                                      $event.preventDefault()
+                                      return _vm.previewScreenLink.apply(
+                                        null,
+                                        arguments
+                                      )
+                                    },
+                                  },
+                                },
+                                [_vm._v("Preview target screen")]
+                              ),
+                            ]),
+                          ]
+                        ),
+                        _vm._v(" "),
+                        _c(
+                          "div",
+                          {
+                            directives: [
+                              {
+                                name: "show",
+                                rawName: "v-show",
+                                value: _vm.linkAction === "url",
+                                expression: "linkAction === 'url'",
+                              },
+                            ],
+                            staticClass: "form-group",
+                          },
+                          [
+                            _c("div", { ref: "urlLinkProvider" }),
+                            _vm._v(" "),
+                            _vm.errors.urlLink
+                              ? _c("div", { staticClass: "text-danger" }, [
+                                  _vm._v(_vm._s(_vm.errors.urlLink)),
+                                ])
+                              : _vm._e(),
+                          ]
+                        ),
+                      ]
+                    ),
+                    _vm._v(" "),
+                    _c("p", { staticClass: "step-summary" }, [
+                      _c(
+                        "a",
+                        {
+                          staticClass: "btn btn-default",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function ($event) {
+                              $event.preventDefault()
+                              return _vm.cancel.apply(null, arguments)
+                            },
+                          },
+                        },
+                        [_vm._v("Cancel")]
+                      ),
+                      _vm._v(" "),
+                      _c(
+                        "a",
+                        {
+                          staticClass: "btn btn-primary",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function ($event) {
+                              $event.preventDefault()
+                              return _vm.nextStep.apply(null, arguments)
+                            },
+                          },
+                        },
+                        [_vm._v("Select recipients")]
+                      ),
+                      _c("br"),
+                      _vm._v(" "),
+                      _c(
+                        "a",
+                        {
+                          staticClass: "btn btn-link",
+                          attrs: { href: "#" },
+                          on: {
+                            click: function ($event) {
+                              $event.preventDefault()
+                              return _vm.save("draft")
+                            },
+                          },
+                        },
+                        [_vm._v("Save as draft")]
+                      ),
+                    ]),
+                  ]),
+                ]
+              ),
+              _vm._v(" "),
+              _vm.steps[_vm.step].name === "recipients"
+                ? _c("div", { staticClass: "row" }, [
+                    _c(
+                      "div",
+                      { staticClass: "col-md-10 col-md-offset-1" },
+                      [
+                        _c("h3", [_vm._v("Send notification to...")]),
+                        _vm._v(" "),
+                        _c("div", { staticClass: "tab-selection" }, [
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab",
+                              class: { active: _vm.audience === "" },
+                              on: {
+                                click: function ($event) {
+                                  _vm.audience = ""
+                                },
+                              },
+                            },
+                            [_vm._v("All users")]
+                          ),
+                          _vm._v(" "),
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab",
+                              class: { active: _vm.audience === "loggedIn" },
+                              on: {
+                                click: function ($event) {
+                                  _vm.audience = "loggedIn"
+                                },
+                              },
+                            },
+                            [_vm._v("Signed in users")]
+                          ),
+                          _vm._v(" "),
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab",
+                              class: { active: _vm.audience === "sessions" },
+                              on: {
+                                click: function ($event) {
+                                  _vm.audience = "sessions"
+                                },
+                              },
+                            },
+                            [_vm._v("Test sessions")]
+                          ),
+                        ]),
+                        _vm._v(" "),
+                        _vm.audience !== "sessions" && _vm.filters.length
+                          ? [
+                              _c("h4", [
+                                _vm._v(
+                                  "Recipients must match all of the following"
+                                ),
+                              ]),
+                              _vm._v(" "),
+                              _vm._l(_vm.filters, function (filter, index) {
+                                return _c(
+                                  "div",
+                                  { key: index, staticClass: "filters" },
+                                  [
+                                    _c(
+                                      "div",
+                                      { staticClass: "form-group clearfix" },
+                                      [
+                                        _c("div", { staticClass: "col-xs-1" }, [
+                                          _c(
+                                            "span",
+                                            {
+                                              staticClass:
+                                                "btn btn-circle btn-default",
+                                              on: {
+                                                click: function ($event) {
+                                                  return _vm.removeFilter(index)
+                                                },
+                                              },
+                                            },
+                                            [
+                                              _c("i", {
+                                                staticClass:
+                                                  "fa fa-fw fa-minus",
+                                              }),
+                                            ]
+                                          ),
+                                        ]),
+                                        _vm._v(" "),
+                                        _c("div", { staticClass: "col-xs-4" }, [
+                                          _c("p", [
+                                            _c("input", {
+                                              directives: [
+                                                {
+                                                  name: "model",
+                                                  rawName: "v-model",
+                                                  value: filter.column,
+                                                  expression: "filter.column",
+                                                },
+                                              ],
+                                              staticClass: "form-control",
+                                              attrs: {
+                                                type: "text",
+                                                placeholder: "Field name",
+                                              },
+                                              domProps: {
+                                                value: filter.column,
+                                              },
+                                              on: {
+                                                input: function ($event) {
+                                                  if ($event.target.composing) {
+                                                    return
+                                                  }
+                                                  _vm.$set(
+                                                    filter,
+                                                    "column",
+                                                    $event.target.value
+                                                  )
+                                                },
+                                              },
+                                            }),
+                                          ]),
+                                          _vm._v(" "),
+                                          _c(
+                                            "div",
+                                            {
+                                              staticClass:
+                                                "form-inline filter-path",
+                                            },
+                                            [
+                                              !_vm.showFilterPath(filter)
+                                                ? _c(
+                                                    "a",
+                                                    {
+                                                      staticClass: "add-path",
+                                                      attrs: {
+                                                        href: "#",
+                                                        tabindex: "-1",
+                                                      },
+                                                      on: {
+                                                        click: function (
+                                                          $event
+                                                        ) {
+                                                          $event.preventDefault()
+                                                          return _vm.addFilterPath(
+                                                            filter
+                                                          )
+                                                        },
+                                                      },
+                                                    },
+                                                    [
+                                                      _vm._v(
+                                                        "This field is an object"
+                                                      ),
+                                                    ]
+                                                  )
+                                                : _c(
+                                                    "div",
+                                                    {
+                                                      staticClass: "form-group",
+                                                    },
+                                                    [
+                                                      _c(
+                                                        "label",
+                                                        {
+                                                          staticClass:
+                                                            "filter-path-label",
+                                                        },
+                                                        [_vm._v("Path")]
+                                                      ),
+                                                      _vm._v(" "),
+                                                      _c("input", {
+                                                        directives: [
+                                                          {
+                                                            name: "model",
+                                                            rawName: "v-model",
+                                                            value: filter.path,
+                                                            expression:
+                                                              "filter.path",
+                                                          },
+                                                        ],
+                                                        staticClass:
+                                                          "form-control",
+                                                        attrs: {
+                                                          type: "text",
+                                                          placeholder:
+                                                            "e.g. companies[0].name",
+                                                        },
+                                                        domProps: {
+                                                          value: filter.path,
+                                                        },
+                                                        on: {
+                                                          input: function (
+                                                            $event
+                                                          ) {
+                                                            if (
+                                                              $event.target
+                                                                .composing
+                                                            ) {
+                                                              return
+                                                            }
+                                                            _vm.$set(
+                                                              filter,
+                                                              "path",
+                                                              $event.target
+                                                                .value
+                                                            )
+                                                          },
+                                                        },
+                                                      }),
+                                                      _vm._v(" "),
+                                                      _c("i", {
+                                                        staticClass:
+                                                          "fa fa-fw fa-times",
+                                                        on: {
+                                                          click: function (
+                                                            $event
+                                                          ) {
+                                                            return _vm.removeFilterPath(
+                                                              filter
+                                                            )
+                                                          },
+                                                        },
+                                                      }),
+                                                    ]
+                                                  ),
+                                            ]
+                                          ),
+                                        ]),
+                                        _vm._v(" "),
+                                        _c("div", { staticClass: "col-xs-3" }, [
+                                          _c(
+                                            "label",
+                                            {
+                                              staticClass:
+                                                "select-proxy-display",
+                                            },
+                                            [
+                                              _c(
+                                                "select",
+                                                {
+                                                  directives: [
+                                                    {
+                                                      name: "model",
+                                                      rawName: "v-model",
+                                                      value: filter.condition,
+                                                      expression:
+                                                        "filter.condition",
+                                                    },
+                                                  ],
+                                                  staticClass:
+                                                    "hidden-select form-control",
+                                                  on: {
+                                                    change: function ($event) {
+                                                      var $$selectedVal =
+                                                        Array.prototype.filter
+                                                          .call(
+                                                            $event.target
+                                                              .options,
+                                                            function (o) {
+                                                              return o.selected
+                                                            }
+                                                          )
+                                                          .map(function (o) {
+                                                            var val =
+                                                              "_value" in o
+                                                                ? o._value
+                                                                : o.value
+                                                            return val
+                                                          })
+                                                      _vm.$set(
+                                                        filter,
+                                                        "condition",
+                                                        $event.target.multiple
+                                                          ? $$selectedVal
+                                                          : $$selectedVal[0]
+                                                      )
+                                                    },
+                                                  },
+                                                },
+                                                _vm._l(
+                                                  _vm.filterTypes,
+                                                  function (type) {
+                                                    return _c("option", {
+                                                      key: type.name,
+                                                      domProps: {
+                                                        value: type.name,
+                                                        innerHTML: _vm._s(
+                                                          type.label
+                                                        ),
+                                                      },
+                                                    })
+                                                  }
+                                                ),
+                                                0
+                                              ),
+                                              _vm._v(" "),
+                                              _c("span", {
+                                                staticClass:
+                                                  "icon fa fa-chevron-down",
+                                              }),
+                                            ]
+                                          ),
+                                        ]),
+                                        _vm._v(" "),
+                                        _c(
+                                          "div",
+                                          { staticClass: "col-xs-4" },
+                                          [
+                                            _c("Filter-Value", {
+                                              attrs: {
+                                                type: _vm.getFilterValueType(
+                                                  filter
+                                                ),
+                                                value: filter.value,
+                                              },
+                                              on: {
+                                                "update:value": function (
+                                                  $event
+                                                ) {
+                                                  return _vm.$set(
+                                                    filter,
+                                                    "value",
+                                                    $event
+                                                  )
+                                                },
+                                              },
+                                            }),
+                                          ],
+                                          1
+                                        ),
+                                      ]
+                                    ),
+                                  ]
+                                )
+                              }),
+                            ]
+                          : _vm._e(),
+                        _vm._v(" "),
+                        _vm.audience === "sessions"
+                          ? [
+                              _c("h4", [_vm._v("Session IDs")]),
+                              _vm._v(" "),
+                              _c("p", { staticClass: "text-center" }, [
+                                _vm._v(
+                                  "To test notifications with individual devices, enter the session ID for each device."
+                                ),
+                              ]),
+                              _vm._v(" "),
+                              _c(
+                                "p",
+                                [
+                                  _c("Token-Field", {
+                                    attrs: {
+                                      value: _vm.sessions,
+                                      placeholder:
+                                        "Separate multiple IDs with commas",
+                                    },
+                                    on: {
+                                      "update:value": function ($event) {
+                                        _vm.sessions = $event
+                                      },
+                                    },
+                                  }),
+                                ],
+                                1
+                              ),
+                              _vm._v(" "),
+                              _vm._m(0),
+                              _vm._v(" "),
+                              _vm.errors.sessions
+                                ? _c(
+                                    "p",
+                                    { staticClass: "text-center text-danger" },
+                                    [_vm._v(_vm._s(_vm.errors.sessions))]
+                                  )
+                                : _vm._e(),
+                            ]
+                          : _vm._e(),
+                        _vm._v(" "),
+                        _c("div", { staticClass: "col-xs-12 filter-summary" }, [
+                          _c("div", { staticClass: "col-xs-8" }, [
+                            _vm.audience !== "sessions"
+                              ? _c("p", [
+                                  _c(
+                                    "a",
+                                    {
+                                      staticClass: "btn btn-default",
+                                      attrs: { href: "#" },
+                                      on: {
+                                        click: function ($event) {
+                                          $event.preventDefault()
+                                          return _vm.addFilter.apply(
+                                            null,
+                                            arguments
+                                          )
+                                        },
+                                      },
+                                    },
+                                    [
+                                      _c("i", {
+                                        staticClass: "fa fa-fw fa-plus",
+                                      }),
+                                      _vm._v(" Add filter"),
+                                    ]
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "a",
+                                    {
+                                      staticClass: "filter-help",
+                                      attrs: {
+                                        href: "https://help.fliplet.com/notifications-component/",
+                                        target: "_blank",
+                                      },
+                                    },
+                                    [
+                                      _vm._v(
+                                        "How to add data for filtering users"
+                                      ),
+                                    ]
+                                  ),
+                                ])
+                              : _vm._e(),
+                          ]),
+                          _vm._v(" "),
+                          _c("div", { staticClass: "col-xs-4 text-right" }, [
+                            _c("p", [
+                              _vm.audience !== "" || _vm.filterScopes.length
+                                ? _c(
+                                    "span",
+                                    { staticClass: "recipient-count" },
+                                    [
+                                      _vm.loadingMatches
+                                        ? [
+                                            _vm._v(
+                                              "\n                    Estimating...\n                  "
+                                            ),
+                                          ]
+                                        : [
+                                            _vm._v(
+                                              "\n                    Estimated: " +
+                                                _vm._s(_vm.matches.count) +
+                                                " user"
+                                            ),
+                                            _vm.matches.count !== 1
+                                              ? [_vm._v("s")]
+                                              : _vm._e(),
+                                            _vm._v(" "),
+                                            _c(
+                                              "tooltip",
+                                              {
+                                                attrs: {
+                                                  title:
+                                                    "This is an approximation and will depend on the user preference at the time of publish. Users who have never used the project will be excluded.",
+                                                },
+                                              },
+                                              [
+                                                _c("i", {
+                                                  staticClass:
+                                                    "fa fa-info-circle",
+                                                }),
+                                              ]
+                                            ),
+                                          ],
+                                    ],
+                                    2
+                                  )
+                                : _vm._e(),
+                            ]),
+                          ]),
+                        ]),
+                        _vm._v(" "),
+                        _c("div", { staticClass: "form-group" }, [
+                          _c("h3", [_vm._v("Notes")]),
+                          _vm._v(" "),
+                          _c("textarea", {
+                            directives: [
+                              {
+                                name: "model",
+                                rawName: "v-model",
+                                value: _vm.notes,
+                                expression: "notes",
+                              },
+                            ],
+                            staticClass: "form-control",
+                            attrs: {
+                              rows: "4",
+                              placeholder:
+                                "(Optional) Add some notes to this notification. Your users will not see this.",
+                            },
+                            domProps: { value: _vm.notes },
+                            on: {
+                              input: function ($event) {
+                                if ($event.target.composing) {
+                                  return
+                                }
+                                _vm.notes = $event.target.value
+                              },
+                            },
+                          }),
+                        ]),
+                        _vm._v(" "),
+                        _c("p", { staticClass: "step-summary" }, [
+                          _c(
+                            "a",
+                            {
+                              staticClass: "btn btn-default",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function ($event) {
+                                  $event.preventDefault()
+                                  return _vm.prevStep.apply(null, arguments)
+                                },
+                              },
+                            },
+                            [_vm._v("Back")]
+                          ),
+                          _vm._v(" "),
+                          _c(
+                            "a",
+                            {
+                              staticClass: "btn btn-primary",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function ($event) {
+                                  $event.preventDefault()
+                                  return _vm.nextStep.apply(null, arguments)
+                                },
+                              },
+                            },
+                            [_vm._v("Prepare for send")]
+                          ),
+                          _c("br"),
+                          _vm._v(" "),
+                          _c(
+                            "a",
+                            {
+                              staticClass: "btn btn-link",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function ($event) {
+                                  $event.preventDefault()
+                                  return _vm.save("draft")
+                                },
+                              },
+                            },
+                            [_vm._v("Save as draft")]
+                          ),
+                        ]),
+                      ],
+                      2
+                    ),
+                  ])
+                : _vm._e(),
+              _vm._v(" "),
+              _vm.steps[_vm.step].name === "schedule"
+                ? [
+                    _vm._m(1),
+                    _vm._v(" "),
+                    _c("div", { staticClass: "row" }, [
+                      _c("div", { staticClass: "col-md-8 col-md-offset-2" }, [
+                        _c("div", { staticClass: "tab-selection" }, [
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab",
+                              class: { active: _vm.schedule === "now" },
+                              on: {
+                                click: function ($event) {
+                                  _vm.schedule = "now"
+                                },
+                              },
+                            },
+                            [_vm._v("Now")]
+                          ),
+                          _vm._v(" "),
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab",
+                              class: { active: _vm.schedule === "scheduled" },
+                              on: {
+                                click: function ($event) {
+                                  _vm.schedule = "scheduled"
+                                },
+                              },
+                            },
+                            [_vm._v("Later")]
+                          ),
+                        ]),
+                      ]),
+                    ]),
+                    _vm._v(" "),
+                    _vm.schedule === "scheduled"
+                      ? _c("div", { staticClass: "row" }, [
+                          _c(
+                            "div",
+                            {
+                              staticClass:
+                                "col-md-8 col-md-offset-2 text-center",
+                            },
+                            [
+                              _c("Datepicker", {
+                                attrs: {
+                                  inline: true,
+                                  "monday-first": true,
+                                  required: true,
+                                  "disabled-dates": _vm.disabledDates,
+                                },
+                                on: {
+                                  changedMonth: _vm.autosize,
+                                  changedYear: _vm.autosize,
+                                  changedDecade: _vm.autosize,
+                                },
+                                model: {
+                                  value: _vm.scheduledAtDate,
+                                  callback: function ($$v) {
+                                    _vm.scheduledAtDate = $$v
+                                  },
+                                  expression: "scheduledAtDate",
+                                },
+                              }),
+                              _vm._v(" "),
+                              _c("Timepicker", {
+                                attrs: {
+                                  hour: _vm.scheduledAtHour,
+                                  minute: _vm.scheduledAtMinute,
+                                  timezone: _vm.scheduledAtTimezone,
+                                  date: _vm.scheduledAtDate,
+                                },
+                                on: {
+                                  "update:hour": function ($event) {
+                                    _vm.scheduledAtHour = $event
+                                  },
+                                  "update:minute": function ($event) {
+                                    _vm.scheduledAtMinute = $event
+                                  },
+                                  "update:timezone": function ($event) {
+                                    _vm.scheduledAtTimezone = $event
+                                  },
+                                  "update:date": function ($event) {
+                                    _vm.scheduledAtDate = $event
+                                  },
+                                },
+                              }),
+                            ],
+                            1
+                          ),
+                        ])
+                      : _vm._e(),
+                    _vm._v(" "),
+                    _c("div", { staticClass: "row" }, [
+                      _c("h3", [_vm._v("Show notification as...")]),
+                      _vm._v(" "),
+                      _c("div", { staticClass: "col-md-8 col-md-offset-2" }, [
+                        _c("div", { staticClass: "tab-selection" }, [
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab tab-checked",
+                              class: {
+                                active: _vm.notificationHasChannel("in-app"),
+                              },
+                              on: {
+                                click: function ($event) {
+                                  return _vm.toggleNotificationChannel("in-app")
+                                },
+                              },
+                            },
+                            [_vm._v("In-app notification")]
+                          ),
+                          _vm._v(" "),
+                          _c(
+                            "span",
+                            {
+                              staticClass: "tab tab-checked",
+                              class: {
+                                active: _vm.notificationHasChannel("push"),
+                              },
+                              on: {
+                                click: function ($event) {
+                                  return _vm.toggleNotificationChannel("push")
+                                },
+                              },
+                            },
+                            [_vm._v("Push notification")]
+                          ),
+                        ]),
+                        _vm._v(" "),
+                        _vm._m(2),
+                        _vm._v(" "),
+                        !_vm.pushIsConfigured
+                          ? _c("div", { staticClass: "alert alert-warning" }, [
+                              _vm._v(
+                                "To send push notifications to your native app, you must configure push notifications on "
+                              ),
+                              _c(
+                                "a",
+                                {
+                                  attrs: {
+                                    href: "https://help.fliplet.com/configure-push-notifications-for-ios/",
+                                    target: "_blank",
+                                  },
+                                },
+                                [_vm._v("iOS")]
+                              ),
+                              _vm._v(" and "),
+                              _c(
+                                "a",
+                                {
+                                  attrs: {
+                                    href: "https://help.fliplet.com/configure-push-notifications-for-android/",
+                                    target: "_blank",
+                                  },
+                                },
+                                [_vm._v("Android")]
+                              ),
+                              _vm._v("."),
+                            ])
+                          : _vm._e(),
+                        _vm._v(" "),
+                        _vm.errors.channels
+                          ? _c(
+                              "p",
+                              { staticClass: "text-center text-danger" },
+                              [_vm._v(_vm._s(_vm.errors.channels))]
+                            )
+                          : _vm._e(),
+                      ]),
+                    ]),
+                    _vm._v(" "),
+                    _c("div", { staticClass: "row" }, [
+                      _c("div", { staticClass: "col-md-8 col-md-offset-2" }, [
+                        _c("p", { staticClass: "step-summary" }, [
+                          _c(
+                            "a",
+                            {
+                              staticClass: "btn btn-default",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function ($event) {
+                                  $event.preventDefault()
+                                  return _vm.prevStep.apply(null, arguments)
+                                },
+                              },
+                            },
+                            [_vm._v("Back")]
+                          ),
+                          _vm._v(" "),
+                          _c(
+                            "a",
+                            {
+                              staticClass: "btn btn-primary",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function ($event) {
+                                  $event.preventDefault()
+                                  return _vm.nextStep.apply(null, arguments)
+                                },
+                              },
+                            },
+                            [_vm._v("Review")]
+                          ),
+                          _c("br"),
+                          _vm._v(" "),
+                          _c(
+                            "a",
+                            {
+                              staticClass: "btn btn-link",
+                              attrs: { href: "#" },
+                              on: {
+                                click: function ($event) {
+                                  $event.preventDefault()
+                                  return _vm.save("draft")
+                                },
+                              },
+                            },
+                            [_vm._v("Save as draft")]
+                          ),
+                        ]),
+                      ]),
+                    ]),
+                  ]
+                : _vm._e(),
+              _vm._v(" "),
+              _c(
+                "div",
+                {
+                  directives: [
+                    {
+                      name: "show",
+                      rawName: "v-show",
+                      value: _vm.steps[_vm.step].name === "review",
+                      expression: "steps[step].name === 'review'",
+                    },
+                  ],
+                  staticClass: "row notification-review",
+                },
+                [
+                  _c(
+                    "div",
+                    { staticClass: "col-md-10 col-md-offset-1" },
+                    [
+                      _c("h3", [_vm._v("Your notification")]),
+                      _vm._v(" "),
+                      _vm.notificationHasChannel("in-app")
+                        ? [
+                            _c("div", { staticClass: "notification-message" }, [
+                              _c("strong", [
+                                _vm._v(_vm._s(_vm.notification.data.title)),
+                              ]),
+                              _c("br"),
+                              _vm._v(
+                                _vm._s(_vm.notification.data.message) +
+                                  "\n            "
+                              ),
+                            ]),
+                          ]
+                        : _vm._e(),
+                      _vm._v(" "),
+                      _vm.notificationHasChannel("push")
+                        ? _c(
+                            "div",
+                            { staticClass: "push-notification-preview" },
+                            [
+                              _vm.notificationHasChannel("in-app")
+                                ? _c("h4", [
+                                    _vm._v(
+                                      "A push notification will also be sent"
+                                    ),
+                                  ])
+                                : _vm._e(),
+                              _vm._v(" "),
+                              _vm._m(3),
+                              _vm._v(" "),
+                              _c(
+                                "div",
+                                {
+                                  staticClass:
+                                    "visible-sm-block visible-md-block visible-lg-block",
+                                  attrs: { id: "notification-message-preview" },
+                                },
+                                [
+                                  _c("img", {
+                                    attrs: {
+                                      src: _vm.getAsset(
+                                        "img/notifications_device_preview_empty.jpg"
+                                      ),
+                                    },
+                                  }),
+                                  _vm._v(" "),
+                                  _c(
+                                    "div",
+                                    {
+                                      attrs: {
+                                        id: "notification-preview-home",
+                                      },
+                                    },
+                                    [
+                                      _c("img", {
+                                        staticClass: "app-icon-preview",
+                                        attrs: { src: _vm.appIcon },
+                                      }),
+                                      _vm._v(" "),
+                                      _c(
+                                        "strong",
+                                        { staticClass: "app-name" },
+                                        [_vm._v(_vm._s(_vm.appName))]
+                                      ),
+                                      _vm._v(" "),
+                                      _c(
+                                        "span",
+                                        { staticClass: "notification-message" },
+                                        [
+                                          _c("strong", [
+                                            _vm._v(
+                                              _vm._s(
+                                                _vm.notification.data.title
+                                              )
+                                            ),
+                                          ]),
+                                          _c("br"),
+                                          _vm._v(
+                                            _vm._s(
+                                              _vm.notification.data.message
+                                            ) + "\n                "
+                                          ),
+                                        ]
+                                      ),
+                                    ]
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "div",
+                                    {
+                                      attrs: {
+                                        id: "notification-preview-icon-home",
+                                      },
+                                    },
+                                    [
+                                      _c("img", {
+                                        staticClass: "app-icon-preview",
+                                        attrs: { src: _vm.appIcon },
+                                      }),
+                                      _vm._v(" "),
+                                      _c(
+                                        "strong",
+                                        { staticClass: "app-name" },
+                                        [_vm._v(_vm._s(_vm.appName))]
+                                      ),
+                                    ]
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "div",
+                                    {
+                                      attrs: {
+                                        id: "notification-preview-lockscreen",
+                                      },
+                                    },
+                                    [
+                                      _c("img", {
+                                        staticClass: "app-icon-preview",
+                                        attrs: { src: _vm.appIcon },
+                                      }),
+                                      _vm._v(" "),
+                                      _c(
+                                        "strong",
+                                        { staticClass: "app-name" },
+                                        [_vm._v(_vm._s(_vm.appName))]
+                                      ),
+                                      _vm._v(" "),
+                                      _c(
+                                        "span",
+                                        { staticClass: "notification-message" },
+                                        [
+                                          _c("strong", [
+                                            _vm._v(
+                                              _vm._s(
+                                                _vm.notification.data.title
+                                              )
+                                            ),
+                                          ]),
+                                          _c("br"),
+                                          _vm._v(
+                                            _vm._s(
+                                              _vm.notification.data.message
+                                            ) + "\n                "
+                                          ),
+                                        ]
+                                      ),
+                                    ]
+                                  ),
+                                  _vm._v(" "),
+                                  _c(
+                                    "div",
+                                    {
+                                      attrs: {
+                                        id: "notification-preview-notification-center",
+                                      },
+                                    },
+                                    [
+                                      _c("img", {
+                                        staticClass: "app-icon-preview",
+                                        attrs: { src: _vm.appIcon },
+                                      }),
+                                      _vm._v(" "),
+                                      _c("strong", { staticClass: "app-name" }),
+                                      _vm._v(" "),
+                                      _c(
+                                        "span",
+                                        { staticClass: "notification-message" },
+                                        [
+                                          _c("strong", [
+                                            _vm._v(
+                                              _vm._s(
+                                                _vm.notification.data.title
+                                              )
+                                            ),
+                                          ]),
+                                          _c("br"),
+                                          _vm._v(
+                                            _vm._s(
+                                              _vm.notification.data.message
+                                            ) + "\n                "
+                                          ),
+                                        ]
+                                      ),
+                                    ]
+                                  ),
+                                ]
+                              ),
+                            ]
+                          )
+                        : _vm._e(),
+                      _vm._v(" "),
+                      _c(
+                        "h4",
+                        [
+                          _vm._v("Sending to\n            "),
+                          _vm.audience === "" && !_vm.filterScopes.length
+                            ? [_vm._v("all users")]
+                            : [
+                                _c("strong", [
+                                  _vm._v(_vm._s(_vm.matches.count)),
+                                ]),
+                                _vm._v(
+                                  " " + _vm._s(_vm.audienceVerbose) + " user"
+                                ),
+                                _vm.matches.count !== 1
+                                  ? [_vm._v("s")]
+                                  : _vm._e(),
+                              ],
+                          _vm._v(" "),
+                          _vm.filterScopes.length
+                            ? [_vm._v("matching all of the following")]
+                            : _vm._e(),
+                        ],
+                        2
+                      ),
+                      _vm._v(" "),
+                      _vm.filterScopes.length
+                        ? [
+                            _c(
+                              "ul",
+                              { staticClass: "filter-summary-items" },
+                              _vm._l(_vm.filters, function (filter, index) {
+                                return _c("li", {
+                                  key: index,
+                                  domProps: {
+                                    innerHTML: _vm._s(
+                                      _vm.getFilterVerbose(filter)
+                                    ),
+                                  },
+                                })
+                              }),
+                              0
+                            ),
+                          ]
+                        : _vm._e(),
+                      _vm._v(" "),
+                      _c("h4", [
+                        _vm._v(
+                          "Send the notification " + _vm._s(_vm.scheduleVerbose)
+                        ),
+                      ]),
+                      _vm._v(" "),
+                      _vm.schedule === "scheduled"
+                        ? _c("p", {
+                            domProps: {
+                              innerHTML: _vm._s(_vm.notificationDate),
+                            },
+                          })
+                        : _vm._e(),
+                      _vm._v(" "),
+                      _c("p", { staticClass: "step-summary" }, [
+                        _c(
+                          "a",
+                          {
+                            staticClass: "btn btn-default",
+                            attrs: { href: "#" },
+                            on: {
+                              click: function ($event) {
+                                $event.preventDefault()
+                                return _vm.prevStep.apply(null, arguments)
+                              },
+                            },
+                          },
+                          [_vm._v("Back")]
+                        ),
+                        _vm._v(" "),
+                        _c("a", {
+                          staticClass: "btn btn-primary",
+                          attrs: { href: "#" },
+                          domProps: { innerHTML: _vm._s(_vm.getSendLabel()) },
+                          on: {
+                            click: function ($event) {
+                              $event.preventDefault()
+                              return _vm.send()
+                            },
+                          },
+                        }),
+                        _c("br"),
+                        _vm._v(" "),
+                        _c(
+                          "a",
+                          {
+                            staticClass: "btn btn-link",
+                            attrs: { href: "#" },
+                            on: {
+                              click: function ($event) {
+                                $event.preventDefault()
+                                return _vm.save("draft")
+                              },
+                            },
+                          },
+                          [_vm._v("Save as draft")]
+                        ),
+                      ]),
+                    ],
+                    2
+                  ),
+                ]
+              ),
+            ],
+            2
+          ),
+    ]),
+  ])
+}
+var staticRenderFns = [
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("p", { staticClass: "help-block text-center" }, [
+      _vm._v("You can find your session ID by going to "),
+      _c("strong", [_vm._v("About this app")]),
+      _vm._v(" in the app on your device."),
+    ])
+  },
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("div", { staticClass: "row" }, [
+      _c("div", { staticClass: "col-md-10 col-md-offset-1" }, [
+        _c("h3", [_vm._v("Send notification...")]),
+      ]),
+    ])
+  },
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("div", { staticClass: "alert alert-info" }, [
+      _c("strong", [_vm._v("New!")]),
+      _vm._v(" Web apps can now receive push notifications."),
+    ])
+  },
+  function () {
+    var _vm = this
+    var _h = _vm.$createElement
+    var _c = _vm._self._c || _h
+    return _c("p", [
+      _c("small", { staticClass: "text-info" }, [
+        _vm._v(
+          "Appearance of the notification is subject to users' device, preference and accepting to receive notifications."
+        ),
+      ]),
+    ])
+  },
+]
+render._withStripped = true
+
 
 
 /***/ }),
@@ -3118,6 +4428,257 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _Timepicker__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(55);
 /* harmony import */ var _TokenField__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(50);
 /* harmony import */ var vuejs_datepicker__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(60);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
 
 
 
@@ -4073,10 +5634,10 @@ component.options.__file = "src/components/FilterValue.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_FilterValue_vue_vue_type_template_id_50266a59__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(47);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_FilterValue_vue_vue_type_template_id_50266a59__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_FilterValue_vue_vue_type_template_id_50266a59__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(47);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_FilterValue_vue_vue_type_template_id_50266a59__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_FilterValue_vue_vue_type_template_id_50266a59__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_FilterValue_vue_vue_type_template_id_50266a59__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -4088,43 +5649,54 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", [_vm.type === "text" ? _c("input", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.value,
-      expression: "value"
-    }],
-    staticClass: "form-control",
-    attrs: {
-      type: "text",
-      placeholder: "Value"
-    },
-    domProps: {
-      value: _vm.value
-    },
-    on: {
-      input: function input($event) {
-        if ($event.target.composing) return;
-        _vm.value = $event.target.value;
-      }
-    }
-  }) : _vm._e(), _vm._v(" "), _vm.type === "collection" ? _c("Token-Field", {
-    attrs: {
-      value: _vm.value
-    },
-    on: {
-      "update:value": function updateValue($event) {
-        _vm.value = $event;
-      }
-    }
-  }) : _vm._e()], 1);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c(
+    "div",
+    [
+      _vm.type === "text"
+        ? _c("input", {
+            directives: [
+              {
+                name: "model",
+                rawName: "v-model",
+                value: _vm.value,
+                expression: "value",
+              },
+            ],
+            staticClass: "form-control",
+            attrs: { type: "text", placeholder: "Value" },
+            domProps: { value: _vm.value },
+            on: {
+              input: function ($event) {
+                if ($event.target.composing) {
+                  return
+                }
+                _vm.value = $event.target.value
+              },
+            },
+          })
+        : _vm._e(),
+      _vm._v(" "),
+      _vm.type === "collection"
+        ? _c("Token-Field", {
+            attrs: { value: _vm.value },
+            on: {
+              "update:value": function ($event) {
+                _vm.value = $event
+              },
+            },
+          })
+        : _vm._e(),
+    ],
+    1
+  )
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -4143,6 +5715,14 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _TokenField__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(50);
+//
+//
+//
+//
+//
+//
+//
+
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   props: {
@@ -4200,10 +5780,10 @@ component.options.__file = "src/components/TokenField.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_TokenField_vue_vue_type_template_id_285f3c31__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(52);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_TokenField_vue_vue_type_template_id_285f3c31__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TokenField_vue_vue_type_template_id_285f3c31__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(52);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TokenField_vue_vue_type_template_id_285f3c31__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_TokenField_vue_vue_type_template_id_285f3c31__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_TokenField_vue_vue_type_template_id_285f3c31__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -4215,35 +5795,38 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("span", [_c("input", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.value,
-      expression: "value"
-    }],
-    ref: "input",
-    staticClass: "form-control",
-    attrs: {
-      type: "text",
-      placeholder: _vm.placeholder
-    },
-    domProps: {
-      value: _vm.value
-    },
-    on: {
-      input: function input($event) {
-        if ($event.target.composing) return;
-        _vm.value = $event.target.value;
-      }
-    }
-  })]);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("span", [
+    _c("input", {
+      directives: [
+        {
+          name: "model",
+          rawName: "v-model",
+          value: _vm.value,
+          expression: "value",
+        },
+      ],
+      ref: "input",
+      staticClass: "form-control",
+      attrs: { type: "text", placeholder: _vm.placeholder },
+      domProps: { value: _vm.value },
+      on: {
+        input: function ($event) {
+          if ($event.target.composing) {
+            return
+          }
+          _vm.value = $event.target.value
+        },
+      },
+    }),
+  ])
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -4261,6 +5844,13 @@ __webpack_require__.r(__webpack_exports__);
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
+//
+//
+//
+//
+//
+//
+
 /* harmony default export */ __webpack_exports__["default"] = ({
   data: function data() {
     return {
@@ -4351,10 +5941,10 @@ component.options.__file = "src/components/Timepicker.vue"
 
 "use strict";
 __webpack_require__.r(__webpack_exports__);
-/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Timepicker_vue_vue_type_template_id_dcdfbb6a__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(57);
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Timepicker_vue_vue_type_template_id_dcdfbb6a__WEBPACK_IMPORTED_MODULE_0__["render"]; });
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Timepicker_vue_vue_type_template_id_dcdfbb6a__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(57);
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Timepicker_vue_vue_type_template_id_dcdfbb6a__WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
-/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_loaders_templateLoader_js_ref_6_node_modules_vue_loader_lib_index_js_vue_loader_options_Timepicker_vue_vue_type_template_id_dcdfbb6a__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_Timepicker_vue_vue_type_template_id_dcdfbb6a__WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 
@@ -4366,153 +5956,187 @@ __webpack_require__.r(__webpack_exports__);
 __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
-var render = function render() {
-  var _vm = this,
-    _c = _vm._self._c;
-  return _c("div", {
-    staticClass: "time-picker"
-  }, [_c("div", {
-    staticClass: "col-xs-2"
-  }, [_c("label", {
-    staticClass: "select-proxy-display"
-  }, [_c("select", {
-    directives: [{
-      name: "model",
-      rawName: "v-model.number",
-      value: _vm.hour12h,
-      expression: "hour12h",
-      modifiers: {
-        number: true
-      }
-    }],
-    staticClass: "hidden-select form-control",
-    on: {
-      change: function change($event) {
-        var $$selectedVal = Array.prototype.filter.call($event.target.options, function (o) {
-          return o.selected;
-        }).map(function (o) {
-          var val = "_value" in o ? o._value : o.value;
-          return _vm._n(val);
-        });
-        _vm.hour12h = $event.target.multiple ? $$selectedVal : $$selectedVal[0];
-      }
-    }
-  }, _vm._l(_vm.hours, function (h) {
-    return _c("option", {
-      key: h.value,
-      domProps: {
-        value: h.value,
-        innerHTML: _vm._s(h.label)
-      }
-    });
-  }), 0), _vm._v(" "), _c("span", {
-    staticClass: "icon fa fa-chevron-down"
-  })])]), _vm._v(" "), _c("div", {
-    staticClass: "col-xs-2"
-  }, [_c("label", {
-    staticClass: "select-proxy-display"
-  }, [_c("select", {
-    directives: [{
-      name: "model",
-      rawName: "v-model.number",
-      value: _vm.minute,
-      expression: "minute",
-      modifiers: {
-        number: true
-      }
-    }],
-    staticClass: "hidden-select form-control",
-    on: {
-      change: function change($event) {
-        var $$selectedVal = Array.prototype.filter.call($event.target.options, function (o) {
-          return o.selected;
-        }).map(function (o) {
-          var val = "_value" in o ? o._value : o.value;
-          return _vm._n(val);
-        });
-        _vm.minute = $event.target.multiple ? $$selectedVal : $$selectedVal[0];
-      }
-    }
-  }, _vm._l(_vm.minutes, function (m) {
-    return _c("option", {
-      key: m.value,
-      domProps: {
-        value: m.value,
-        innerHTML: _vm._s(m.label)
-      }
-    });
-  }), 0), _vm._v(" "), _c("span", {
-    staticClass: "icon fa fa-chevron-down"
-  })])]), _vm._v(" "), _c("div", {
-    staticClass: "col-xs-2"
-  }, [_c("label", {
-    staticClass: "select-proxy-display"
-  }, [_c("select", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.ampm,
-      expression: "ampm"
-    }],
-    staticClass: "hidden-select form-control",
-    on: {
-      change: function change($event) {
-        var $$selectedVal = Array.prototype.filter.call($event.target.options, function (o) {
-          return o.selected;
-        }).map(function (o) {
-          var val = "_value" in o ? o._value : o.value;
-          return val;
-        });
-        _vm.ampm = $event.target.multiple ? $$selectedVal : $$selectedVal[0];
-      }
-    }
-  }, [_c("option", {
-    attrs: {
-      value: "AM"
-    }
-  }, [_vm._v("AM")]), _vm._v(" "), _c("option", {
-    attrs: {
-      value: "PM"
-    }
-  }, [_vm._v("PM")])]), _vm._v(" "), _c("span", {
-    staticClass: "icon fa fa-chevron-down"
-  })])]), _vm._v(" "), _c("div", {
-    staticClass: "col-xs-6"
-  }, [_c("label", {
-    staticClass: "select-proxy-display"
-  }, [_c("select", {
-    directives: [{
-      name: "model",
-      rawName: "v-model",
-      value: _vm.timezone,
-      expression: "timezone"
-    }],
-    staticClass: "hidden-select form-control",
-    on: {
-      change: function change($event) {
-        var $$selectedVal = Array.prototype.filter.call($event.target.options, function (o) {
-          return o.selected;
-        }).map(function (o) {
-          var val = "_value" in o ? o._value : o.value;
-          return val;
-        });
-        _vm.timezone = $event.target.multiple ? $$selectedVal : $$selectedVal[0];
-      }
-    }
-  }, _vm._l(_vm.adjustedTimezones, function (zone) {
-    return _c("option", {
-      key: zone.value,
-      domProps: {
-        value: zone.value,
-        innerHTML: _vm._s(zone.label)
-      }
-    });
-  }), 0), _vm._v(" "), _c("span", {
-    staticClass: "icon fa fa-chevron-down"
-  })])])]);
-};
-var staticRenderFns = [];
-render._withStripped = true;
+var render = function () {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("div", { staticClass: "time-picker" }, [
+    _c("div", { staticClass: "col-xs-2" }, [
+      _c("label", { staticClass: "select-proxy-display" }, [
+        _c(
+          "select",
+          {
+            directives: [
+              {
+                name: "model",
+                rawName: "v-model.number",
+                value: _vm.hour12h,
+                expression: "hour12h",
+                modifiers: { number: true },
+              },
+            ],
+            staticClass: "hidden-select form-control",
+            on: {
+              change: function ($event) {
+                var $$selectedVal = Array.prototype.filter
+                  .call($event.target.options, function (o) {
+                    return o.selected
+                  })
+                  .map(function (o) {
+                    var val = "_value" in o ? o._value : o.value
+                    return _vm._n(val)
+                  })
+                _vm.hour12h = $event.target.multiple
+                  ? $$selectedVal
+                  : $$selectedVal[0]
+              },
+            },
+          },
+          _vm._l(_vm.hours, function (h) {
+            return _c("option", {
+              key: h.value,
+              domProps: { value: h.value, innerHTML: _vm._s(h.label) },
+            })
+          }),
+          0
+        ),
+        _vm._v(" "),
+        _c("span", { staticClass: "icon fa fa-chevron-down" }),
+      ]),
+    ]),
+    _vm._v(" "),
+    _c("div", { staticClass: "col-xs-2" }, [
+      _c("label", { staticClass: "select-proxy-display" }, [
+        _c(
+          "select",
+          {
+            directives: [
+              {
+                name: "model",
+                rawName: "v-model.number",
+                value: _vm.minute,
+                expression: "minute",
+                modifiers: { number: true },
+              },
+            ],
+            staticClass: "hidden-select form-control",
+            on: {
+              change: function ($event) {
+                var $$selectedVal = Array.prototype.filter
+                  .call($event.target.options, function (o) {
+                    return o.selected
+                  })
+                  .map(function (o) {
+                    var val = "_value" in o ? o._value : o.value
+                    return _vm._n(val)
+                  })
+                _vm.minute = $event.target.multiple
+                  ? $$selectedVal
+                  : $$selectedVal[0]
+              },
+            },
+          },
+          _vm._l(_vm.minutes, function (m) {
+            return _c("option", {
+              key: m.value,
+              domProps: { value: m.value, innerHTML: _vm._s(m.label) },
+            })
+          }),
+          0
+        ),
+        _vm._v(" "),
+        _c("span", { staticClass: "icon fa fa-chevron-down" }),
+      ]),
+    ]),
+    _vm._v(" "),
+    _c("div", { staticClass: "col-xs-2" }, [
+      _c("label", { staticClass: "select-proxy-display" }, [
+        _c(
+          "select",
+          {
+            directives: [
+              {
+                name: "model",
+                rawName: "v-model",
+                value: _vm.ampm,
+                expression: "ampm",
+              },
+            ],
+            staticClass: "hidden-select form-control",
+            on: {
+              change: function ($event) {
+                var $$selectedVal = Array.prototype.filter
+                  .call($event.target.options, function (o) {
+                    return o.selected
+                  })
+                  .map(function (o) {
+                    var val = "_value" in o ? o._value : o.value
+                    return val
+                  })
+                _vm.ampm = $event.target.multiple
+                  ? $$selectedVal
+                  : $$selectedVal[0]
+              },
+            },
+          },
+          [
+            _c("option", { attrs: { value: "AM" } }, [_vm._v("AM")]),
+            _vm._v(" "),
+            _c("option", { attrs: { value: "PM" } }, [_vm._v("PM")]),
+          ]
+        ),
+        _vm._v(" "),
+        _c("span", { staticClass: "icon fa fa-chevron-down" }),
+      ]),
+    ]),
+    _vm._v(" "),
+    _c("div", { staticClass: "col-xs-6" }, [
+      _c("label", { staticClass: "select-proxy-display" }, [
+        _c(
+          "select",
+          {
+            directives: [
+              {
+                name: "model",
+                rawName: "v-model",
+                value: _vm.timezone,
+                expression: "timezone",
+              },
+            ],
+            staticClass: "hidden-select form-control",
+            on: {
+              change: function ($event) {
+                var $$selectedVal = Array.prototype.filter
+                  .call($event.target.options, function (o) {
+                    return o.selected
+                  })
+                  .map(function (o) {
+                    var val = "_value" in o ? o._value : o.value
+                    return val
+                  })
+                _vm.timezone = $event.target.multiple
+                  ? $$selectedVal
+                  : $$selectedVal[0]
+              },
+            },
+          },
+          _vm._l(_vm.adjustedTimezones, function (zone) {
+            return _c("option", {
+              key: zone.value,
+              domProps: { value: zone.value, innerHTML: _vm._s(zone.label) },
+            })
+          }),
+          0
+        ),
+        _vm._v(" "),
+        _c("span", { staticClass: "icon fa fa-chevron-down" }),
+      ]),
+    ]),
+  ])
+}
+var staticRenderFns = []
+render._withStripped = true
+
 
 
 /***/ }),
@@ -4531,6 +6155,45 @@ __webpack_require__.r(__webpack_exports__);
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _libs_timezones__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(38);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+
 
 /* harmony default export */ __webpack_exports__["default"] = ({
   data: function data() {


### PR DESCRIPTION
[DEV-1297](https://weboo.atlassian.net/browse/DEV-1297)

Follow-up to #225. The rename PR updated source but didn't include a rebuilt `dist/app.js`, so the deployed widget kept rendering pre-rename copy in the settings overlay and notification list:

> "publish your **app**" → should be "project"
> "first screen of the **app**" → should be "project"
> "**Apps** inside a portal" → should be "Projects"
> "Users who have never used the **app**" → should be "project"
> "re-engage with your **app**" → should be "project"

Ran \`npm run build\` from `production` so the bundle matches the source already merged.

No source changes — `git diff production..HEAD -- src/ interface.html` is empty.

⚠️ Bundle size jumps 245KB → 315KB. That's because the local `node_modules` resolves a slightly different set of webpack module IDs; user-visible strings + runtime behaviour are identical. Verified by grepping the new bundle for the rename strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-1297]: https://weboo.atlassian.net/browse/DEV-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ