### PR TITLE
Release: release/DEV-965 → production

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -60,6 +60,25 @@ Fliplet.Widget.register('PushNotifications', function () {
     if (push) {
       if (subscriptionId) {
         if (subscriptionDetails.token) {
+          // Immediate check: the Cordova plugin fires the 'registration' event very early
+          // at app launch, often before this listener is attached. If registrationId was
+          // already captured by getPushNotificationInstance(), compare it now so we don't
+          // miss a token rotation that happened before this point.
+          var currentToken = typeof Fliplet.User.getRegistrationId === 'function'
+            ? Fliplet.User.getRegistrationId()
+            : undefined;
+
+          if (currentToken && currentToken !== subscriptionDetails.token) {
+            console.info('[push] OS token rotated since last registration — updating subscription');
+            Fliplet.User.updateSubscription({ token: currentToken }).catch(function (err) {
+              console.warn('[push] immediate token update failed', err);
+            });
+            // Update the cached token so the listener below doesn't fire a redundant
+            // updateSubscription if the plugin re-emits 'registration' with the same value.
+            subscriptionDetails.token = currentToken;
+          }
+
+          // Retain the event listener as a fallback for token rotation mid-session
           push.on('registration', function (data) {
             if (data.registrationId === subscriptionDetails.token) {
               return; // token hasn't changed
@@ -68,7 +87,10 @@ Fliplet.Widget.register('PushNotifications', function () {
             // update subscription with new token
             Fliplet.User.updateSubscription({
               token: data.registrationId
+            }).catch(function (err) {
+              console.warn('[push] mid-session token update failed', err);
             });
+            subscriptionDetails.token = data.registrationId;
           });
         }
 

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -57,6 +57,29 @@ Fliplet.Widget.register('PushNotifications', function () {
      */
     var push = Fliplet.User.getPushNotificationInstance(data);
 
+    if (!push && Fliplet.Env.is('web') && subscriptionId && subscriptionDetails.token
+        && typeof Fliplet.User.getCurrentWebPushToken === 'function') {
+      // Web has no Cordova plugin firing a 'registration' event, so instead read
+      // the live SW push subscription once at launch and update the server-side
+      // subscription if the cached token differs from the current browser endpoint.
+      Fliplet.User.getCurrentWebPushToken().then(function (currentToken) {
+        if (!currentToken || currentToken === subscriptionDetails.token) {
+          return;
+        }
+
+        console.info('[push] Web push subscription has rotated since last registration — updating subscription');
+
+        return Fliplet.User.updateSubscription({ token: currentToken }).catch(function (err) {
+          console.warn('[push] web token update failed', err);
+        });
+      }).catch(function (err) {
+        // Defensive outer catch: if fliplet-core's getCurrentWebPushToken contract
+        // ever changes to reject (it currently swallows internally), don't leak an
+        // UnhandledPromiseRejection.
+        console.warn('[push] web token rotation check failed', err);
+      });
+    }
+
     if (push) {
       if (subscriptionId) {
         if (subscriptionDetails.token) {


### PR DESCRIPTION
## Release: `release/DEV-965` → `production`

| Title | Ticket | PR |
|-------|--------|-----|
| Detect token rotation before registration event fires | [DEV-965](https://weboo.atlassian.net/browse/DEV-965) | #222 |
| Detect web token rotation at launch | [DEV-965](https://weboo.atlassian.net/browse/DEV-965) | #223 |

**Scope:** `js/notifications.js` only (45 changed lines). The release branch is 3 commits behind `production` (#225 apps→projects wording, widget.json excludedProperties changes) — a standard merge keeps those production-only commits intact.

### Deployment instructions
- **Deploy order:** the companion API release Fliplet/fliplet-api#8419 must be merged and deployed to all regions **first** — #223 calls `Fliplet.User.getCurrentWebPushToken()`, which only exists in `fliplet-core` after that API release ships. Deploying this widget ahead of it would break the web launch check.
- No other dependencies; no widget.json schema changes in this release.
- Post-deploy: re-run TC 2.1 (edit `push-token-<appId>` in localStorage → refresh → expect `PUT /v1/apps/<appId>/subscriptions/<id>` with the live token) plus the fresh-grant regression (TC 1.1).


[DEV-965]: https://weboo.atlassian.net/browse/DEV-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-965]: https://weboo.atlassian.net/browse/DEV-965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ